### PR TITLE
Basic liquid/limes API server implementation

### DIFF
--- a/cmd/andromeda-liquid-server/main.go
+++ b/cmd/andromeda-liquid-server/main.go
@@ -1,0 +1,176 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"time"
+
+	"github.com/go-openapi/runtime"
+	runtimeclient "github.com/go-openapi/runtime/client"
+	"github.com/go-openapi/strfmt"
+	"github.com/gophercloud/gophercloud/v2"
+	"github.com/sapcc/go-api-declarations/liquid"
+	"github.com/sapcc/go-bits/httpext"
+	"github.com/sapcc/go-bits/liquidapi"
+	"github.com/sapcc/go-bits/must"
+	"github.com/urfave/cli/v2"
+
+	"github.com/sapcc/andromeda/client"
+	"github.com/sapcc/andromeda/client/administrative"
+	"github.com/sapcc/andromeda/internal/config"
+	"github.com/sapcc/andromeda/models"
+)
+
+type liquidLogic struct {
+	andromedaClient *client.Andromeda
+}
+
+func (l *liquidLogic) Init(ctx context.Context, provider *gophercloud.ProviderClient, eo gophercloud.EndpointOpts) error {
+	l.andromedaClient = client.Default
+	endpointOpts := gophercloud.EndpointOpts{
+		Region: eo.Region,
+	}
+	endpointOpts.ApplyDefaults("gtm")
+	endpoint, err := provider.EndpointLocator(endpointOpts)
+	if err != nil {
+		return err
+	}
+	uri, err := url.Parse(endpoint)
+	if err != nil {
+		return err
+	}
+	rt := runtimeclient.New(uri.Host, uri.Path, []string{uri.Scheme})
+	rt.DefaultAuthentication = runtime.ClientAuthInfoWriterFunc(func(req runtime.ClientRequest, reg strfmt.Registry) error {
+		if err := req.SetHeaderParam("X-Auth-Token", provider.Token()); err != nil {
+			return err
+		}
+		return nil
+	})
+	l.andromedaClient.SetTransport(rt)
+	return nil
+}
+
+func (l *liquidLogic) BuildServiceInfo(ctx context.Context) (liquid.ServiceInfo, error) {
+	return liquid.ServiceInfo{
+		Version: 1,
+		Resources: map[liquid.ResourceName]liquid.ResourceInfo{
+			"datacenter": liquid.ResourceInfo{
+				HasCapacity: false,
+				HasQuota:    true,
+				Topology:    liquid.FlatResourceTopology,
+			},
+			"domain": liquid.ResourceInfo{
+				HasCapacity: false,
+				HasQuota:    true,
+				Topology:    liquid.FlatResourceTopology,
+			},
+			"member": liquid.ResourceInfo{
+				HasCapacity: false,
+				HasQuota:    true,
+				Topology:    liquid.FlatResourceTopology,
+			},
+			"monitor": liquid.ResourceInfo{
+				HasCapacity: false,
+				HasQuota:    true,
+				Topology:    liquid.FlatResourceTopology,
+			},
+			"pool": liquid.ResourceInfo{
+				HasCapacity: false,
+				HasQuota:    true,
+				Topology:    liquid.FlatResourceTopology,
+			},
+		},
+		Rates:                  map[liquid.RateName]liquid.RateInfo{},
+		CapacityMetricFamilies: map[liquid.MetricName]liquid.MetricFamilyInfo{},
+	}, nil
+}
+
+func (l *liquidLogic) ScanCapacity(ctx context.Context, req liquid.ServiceCapacityRequest, serviceInfo liquid.ServiceInfo) (liquid.ServiceCapacityReport, error) {
+	return liquid.ServiceCapacityReport{InfoVersion: 1}, nil
+}
+
+func (l *liquidLogic) ScanUsage(ctx context.Context, projectUUID string, req liquid.ServiceUsageRequest, serviceInfo liquid.ServiceInfo) (liquid.ServiceUsageReport, error) {
+	params := administrative.NewGetQuotasProjectIDParams().WithDefaults()
+	params.ProjectID = projectUUID
+	resp, err := l.andromedaClient.Administrative.GetQuotasProjectID(params)
+	if err != nil {
+		return liquid.ServiceUsageReport{}, err
+	}
+	return liquid.ServiceUsageReport{
+		InfoVersion: 1,
+		Resources: map[liquid.ResourceName]*liquid.ResourceUsageReport{
+			"datacenter": &liquid.ResourceUsageReport{
+				Quota: resp.Payload.Quota.Datacenter,
+				PerAZ: map[liquid.AvailabilityZone]*liquid.AZResourceUsageReport{
+					liquid.AvailabilityZoneAny: &liquid.AZResourceUsageReport{Usage: uint64(resp.Payload.Quota.QuotaUsage.InUseDatacenter)},
+				},
+			},
+			"domain": &liquid.ResourceUsageReport{
+				Quota: resp.Payload.Quota.Domain,
+				PerAZ: map[liquid.AvailabilityZone]*liquid.AZResourceUsageReport{
+					liquid.AvailabilityZoneAny: &liquid.AZResourceUsageReport{Usage: uint64(resp.Payload.Quota.QuotaUsage.InUseDomain)},
+				},
+			},
+			"member": &liquid.ResourceUsageReport{
+				Quota: resp.Payload.Quota.Member,
+				PerAZ: map[liquid.AvailabilityZone]*liquid.AZResourceUsageReport{
+					liquid.AvailabilityZoneAny: &liquid.AZResourceUsageReport{Usage: uint64(resp.Payload.Quota.QuotaUsage.InUseMember)},
+				},
+			},
+			"monitor": &liquid.ResourceUsageReport{
+				Quota: resp.Payload.Quota.Monitor,
+				PerAZ: map[liquid.AvailabilityZone]*liquid.AZResourceUsageReport{
+					liquid.AvailabilityZoneAny: &liquid.AZResourceUsageReport{Usage: uint64(resp.Payload.Quota.QuotaUsage.InUseMonitor)},
+				},
+			},
+			"pool": &liquid.ResourceUsageReport{
+				Quota: resp.Payload.Quota.Pool,
+				PerAZ: map[liquid.AvailabilityZone]*liquid.AZResourceUsageReport{
+					liquid.AvailabilityZoneAny: &liquid.AZResourceUsageReport{Usage: uint64(resp.Payload.Quota.QuotaUsage.InUsePool)},
+				},
+			},
+		},
+	}, nil
+}
+
+func (l *liquidLogic) SetQuota(ctx context.Context, projectUUID string, req liquid.ServiceQuotaRequest, serviceInfo liquid.ServiceInfo) error {
+	params := administrative.NewPutQuotasProjectIDParams().WithDefaults()
+	params.ProjectID = projectUUID
+	params.Quota = administrative.PutQuotasProjectIDBody{Quota: &models.Quota{
+		Datacenter: func(num uint64) *int64 { i := int64(num); return &i }(req.Resources["datacenter"].Quota),
+		Domain:     func(num uint64) *int64 { i := int64(num); return &i }(req.Resources["domain"].Quota),
+		Member:     func(num uint64) *int64 { i := int64(num); return &i }(req.Resources["member"].Quota),
+		Monitor:    func(num uint64) *int64 { i := int64(num); return &i }(req.Resources["monitor"].Quota),
+		Pool:       func(num uint64) *int64 { i := int64(num); return &i }(req.Resources["pool"].Quota),
+	}}
+	_, err := l.andromedaClient.Administrative.PutQuotasProjectID(params)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func main() {
+	config.ParseArgsAndRun("andromeda-liquid-api", "andromeda liquid api",
+		func(c *cli.Context) error {
+			ctx := httpext.ContextWithSIGINT(c.Context, 10*time.Second)
+			host := c.String("host")
+			port := c.Int("port")
+			logic := &liquidLogic{}
+			opts := liquidapi.RunOpts{DefaultListenAddress: fmt.Sprintf("%s:%d", host, port)}
+			must.Succeed(liquidapi.Run(ctx, logic, opts))
+			return nil
+		},
+		&cli.StringFlag{
+			Name:  "host",
+			Usage: "The IP to listen on",
+			Value: "0.0.0.0",
+		},
+		&cli.IntFlag{
+			Name:  "port",
+			Usage: "Port to listen",
+			Value: 8080,
+		},
+	)
+}

--- a/go.mod
+++ b/go.mod
@@ -72,6 +72,7 @@ require (
 	github.com/gobuffalo/packr/v2 v2.8.0 // indirect
 	github.com/gofrs/uuid/v5 v5.3.0 // indirect
 	github.com/google/uuid v1.6.0 // indirect
+	github.com/gorilla/mux v1.8.1 // indirect
 	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
 	github.com/hashicorp/go-retryablehttp v0.7.7 // indirect
 	github.com/jackc/pgpassfile v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -142,6 +142,8 @@ github.com/gophercloud/gophercloud/v2 v2.3.0 h1:5ipI2Mgxee0TwQxqnOIUdTbzL4ZBB8GO
 github.com/gophercloud/gophercloud/v2 v2.3.0/go.mod h1:uJWNpTgJPSl2gyzJqcU/pIAhFUWvIkp8eE8M15n9rs4=
 github.com/gophercloud/utils/v2 v2.0.0-20241209100706-e3a3b7c07d26 h1:N65GYmx5LrMeYdeXcxMESDU+2pDyAOXlFNlHl7siUwM=
 github.com/gophercloud/utils/v2 v2.0.0-20241209100706-e3a3b7c07d26/go.mod h1:7SHUbtoiSYINNKgAVxse+PMhIio05IK7shHy8DVRaN0=
+github.com/gorilla/mux v1.8.1 h1:TuBL49tXwgrFYWhqrNgrUNEY92u81SPhu7sTdzQEiWY=
+github.com/gorilla/mux v1.8.1/go.mod h1:AKf9I4AEqPTmMytcMc0KkNouC66V3BtZ4qD5fmWSiMQ=
 github.com/gorilla/websocket v1.4.0/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
 github.com/grpc-ecosystem/go-grpc-middleware v1.0.0/go.mod h1:FiyG127CGDf3tlThmgyCl78X/SZQqEOJBCDaAfeWzPs=
 github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0/go.mod h1:8NvIoxWQoOIhqOTXgfV/d3M/q6VIi02HzZEHgUlZvzk=


### PR DESCRIPTION
This is the implementation of a liquid/limes API server process that serves the following endpoints:

```
# Get resource definitions
GET /v1/info

# Get capacity
POST /v1/report-capacity

# Get project usage and quota
POST /v1/projects/{project-id}/report-usage

# Set/update project quota
PUT /v1/projects/{project-id}/quota
```

## Sample code for manually trying it out

```sh
# Ensure there's an Andromeda config file at project root directory:
cat > config.yaml <<EOF
...
EOF

# Ensure there's an Oslo policy file at the project root directory with the following contents:
cat > policy.json <<EOF
{
  "liquid:get_info": "",
  "liquid:get_capacity": "",
  "liquid:get_usage": "",
  "liquid:set_quota": ""
}
EOF

# Ensure the appropriate OS_* environment variables are set.
# (Shell 1) Starting the server will require OS_PASSWORD to be set.
# (Shell 2) Performing HTTP requests with curl will require OS_TOKEN to be set.

# (Shell 1) Start the API server
export LIQUID_POLICY_PATH="$PWD/policy.json"
go run cmd/andromeda-liquid-server/main.go --config-file config.yaml

# (Shell 2) Export a valid OS_TOKEN
export OS_TOKEN='<...>'

# (Shell 2) Optionally:
export LIQUID_SERVER_URL=http://127.0.0.1:8080

# (Shell 2) Get resource definitions
curl -v -X GET \
    -H "X-Auth-Token: $OS_TOKEN" \
    "$LIQUID_SERVER_URL/v1/info" \
    | jq .

# (Shell 2) Get capacity
curl -v -X POST \
    -H "X-Auth-Token: $OS_TOKEN" \
    -d '{}' \
    "$LIQUID_SERVER_URL/v1/report-capacity" \
    | jq .

# (Shell 2) Get project usage and quota
project_id='<...>' # -> corresponds to Andromeda table/column quota.project_id
curl -v -X POST \
    -H "X-Auth-Token: $OS_TOKEN" \
    -d '{}' \
    "$LIQUID_SERVER_URL/v1/projects/$project_id/report-usage" \
    | jq .

# (Shell 2) Set/update project quota
curl -v -X PUT \
    -H "X-Auth-Token: $OS_TOKEN" \
    -d '{ "resources": { "datacenter": {"quota": 2}, "domain": {"quota": 3}, "member": {"quota": 4}, "monitor": {"quota": 5}, "pool": {"quota": 6} } }' \
    "$LIQUID_SERVER_URL/v1/projects/$project_id/quota"
```
