### PR TITLE
[akamai] fix domains who get all members removed

### DIFF
--- a/internal/driver/akamai/property.go
+++ b/internal/driver/akamai/property.go
@@ -201,8 +201,8 @@ MEMBERLOOP:
 	// Pre-Validation
 	if len(property.TrafficTargets) == 0 {
 		// Need traffictargets with datacenters before posting
-		log.Debugf("Skipping Property '%s': No traffic targets", property.Name)
-		return provRequests, nil
+		log.Infof("Skipping/Deleting Property '%s': No traffic targets", property.Name)
+		return provRequests, s.DeleteProperty(domain, trafficManagementDomain)
 	}
 
 	request := gtm.GetPropertyRequest{


### PR DESCRIPTION
Akamai doesn't support properties without traffic targets, but akamai
does allow domains without members.

So in case an existing domain loses all it's members, we need to remove
the property completely from akamai to replicate the behaviour without
causing an API inconsistency.
