### PR TITLE
akamai edgegrid instrumentation

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -145,6 +145,13 @@ func parseConfigFlags(flags []string) error {
 		Global.Database.Connection = os.Getenv("DATABASE_CONNECTION")
 	}
 
+	// allow env to override config file
+	prometheusListen := os.Getenv("PROMETHEUS_LISTEN")
+	if prometheusListen != "" {
+		Global.Default.PrometheusListen = prometheusListen
+		log.Debug("Using PROMETHEUS_LISTEN")
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
Uses a built-in middleware for instrumenting Akamai EdgeGrid API calls (eliminates the boilerplate from #784).
