### PR TITLE
include build for linux/arm64

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,8 +17,6 @@ jobs:
         exclude:
           - goarch: arm64
             goos: windows
-          - goarch: arm64
-            goos: linux
     steps:
       - uses: actions/checkout@v4
       - uses: wangyoucao577/go-release-action@v1


### PR DESCRIPTION
when running in multiarchitecture docker container, we need to have a version for linx/arm64 too.