### PR TITLE
[akamai] don't fail on syncing datacenters when syncing domains

### DIFF
--- a/internal/driver/akamai/datacenter.go
+++ b/internal/driver/akamai/datacenter.go
@@ -19,6 +19,7 @@ package akamai
 import (
 	"context"
 	"errors"
+	"fmt"
 	"time"
 
 	"github.com/akamai/AkamaiOPEN-edgegrid-golang/v10/pkg/gtm"
@@ -180,8 +181,10 @@ func (s *AkamaiAgent) SyncDatacenter(datacenter *rpcmodels.Datacenter, force boo
 			DatacenterID: backendDatacenter.DatacenterID,
 			DomainName:   config.Global.AkamaiConfig.Domain,
 		}
-		_, err = s.gtm.DeleteDatacenter(context.Background(), request)
-		return nil, err
+		if _, err = s.gtm.DeleteDatacenter(context.Background(), request); err != nil {
+			return nil, fmt.Errorf("DeleteDatacenter(%s) failed: %w", datacenter.Id, err)
+		}
+		return nil, nil
 	}
 
 	// consider synced
@@ -209,7 +212,7 @@ func (s *AkamaiAgent) SyncDatacenter(datacenter *rpcmodels.Datacenter, force boo
 		"Longitude",
 		"Nickname",
 	}
-	if utils.DeepEqualFields(&referenceDatacenter, (*gtm.Datacenter)(backendDatacenter), fieldsToCompare) {
+	if utils.DeepEqualFields(&referenceDatacenter, backendDatacenter, fieldsToCompare) {
 		// no change
 		return datacenter, nil
 	}

--- a/internal/driver/akamai/domain.go
+++ b/internal/driver/akamai/domain.go
@@ -93,7 +93,7 @@ func (s *AkamaiAgent) FetchAndSyncDomains(domains []string, force bool) error {
 	}
 	if len(datacenters) > 0 {
 		if err := s.FetchAndSyncDatacenters(datacenters, false); err != nil {
-			return err
+			log.Warnf("FetchAndSyncDomains(%+v) prior FetchAndSyncDatacenters(%+v): %v", domains, datacenters, err)
 		}
 	}
 


### PR DESCRIPTION
domains that have disasscociated target members need to be updated
before related datacenter can be deleted. This can lead to a dead lock
scenario (sync of domain needs successful sync of datacenter needs
successful sync of domain).

Making the related datacenter sync non-fail will eventually clean up a
interdependency by the regular interval sync.

also, improved some error messages.
