### PR TITLE
fix: intermittent Keystone token validation errors

### DIFF
--- a/internal/auth/keystone.go
+++ b/internal/auth/keystone.go
@@ -47,8 +47,12 @@ type contextKey struct {
 // Middleware Keystone token injector, also implements goslo policy checker
 func KeystoneMiddleware(next http.Handler) (http.Handler, error) {
 	authInfo := config.Global.ServiceAuth
-	providerClient, err := clientconfig.AuthenticatedClient(context.Background(), &clientconfig.ClientOpts{
-		AuthInfo: &authInfo})
+	authOpts, err := clientconfig.AuthOptions(&clientconfig.ClientOpts{AuthInfo: &authInfo})
+	if err != nil {
+		return nil, err
+	}
+	authOpts.AllowReauth = true
+	providerClient, err := openstack.AuthenticatedClient(context.Background(), *authOpts)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
On 26 March 2025 Stefan Majewsky wrote:

> Limes in global prod is getting flooded with

```
2025/03/26 09:40:48 ERROR: during resource scrape of project cc3test/regression: Expected HTTP response code [200] when accessing [POST https://gtm-liquid-3.global.cloud.sap/v1/projects/540e296747ec44b2b9662361fc02eb5d/report-usage], but got 500 instead: [GET /quotas/{project_id}][403] GetQuotasProjectID default  &{Code:401 Message:Unauthorized: Expected HTTP response code [200 203] when accessing [GET http://keystone-global.monsoon3global:5000/v3/auth/tokens], but got 404 instead: {"error":{"code":404,"message":"Failed to validate token","title":"Not Found"}}}
```

> You're calling `clientconfig.AuthenticatedClient()`, which in my experience is not viable for long-running services. Before we switched to go-bits/gophercloudext for auth, we used `clientconfig.AuthOptions()`, like on the red side of this diff: <https://github.com/sapcc/limes/commit/473c3a2fb0101aec28aab24188bf8f9f9e5e9d9b#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261L146-R146>
