### PR TITLE
flavors for domain quotas

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,8 +61,8 @@ bin/%: cmd/%/main.go
 
 swagger: bin/swagger
 	$(SWAGGER) generate server --exclude-main --copyright-file COPYRIGHT.txt
-	$(SWAGGER) generate model --copyright-file COPYRIGHT.txt
 	$(SWAGGER) generate client --copyright-file COPYRIGHT.txt
+	$(SWAGGER) generate model --copyright-file COPYRIGHT.txt --struct-tags db
 
 markdown: bin/swagger
 	$(SWAGGER) generate markdown --copyright-file COPYRIGHT.txt --output docs/api.md

--- a/Makefile
+++ b/Makefile
@@ -65,7 +65,10 @@ swagger: bin/swagger
 	$(SWAGGER) generate client --copyright-file COPYRIGHT.txt
 
 markdown: bin/swagger
-	$(SWAGGER) generate markdown --copyright-file COPYRIGHT.txt --output= docs/api.md
+	$(SWAGGER) generate markdown --copyright-file COPYRIGHT.txt --output docs/api.md
+
+serve-swagger-docs: bin/swagger
+	$(SWAGGER) serve swagger.yml -p 9900
 
 migrate: bin/migrate
 	$(MIGRATE) -path db/migrations -database "cockroachdb://root@localhost:26257/andromeda?sslmode=disable" drop -f

--- a/cmd/andromeda-liquid-server/main.go
+++ b/cmd/andromeda-liquid-server/main.go
@@ -68,6 +68,12 @@ var defaultServiceUsageReport = liquid.ServiceUsageReport{
 				liquid.AvailabilityZoneAny: {Usage: 0},
 			},
 		},
+		"domains_f5": {
+			Quota: swag.Int64(0),
+			PerAZ: map[liquid.AvailabilityZone]*liquid.AZResourceUsageReport{
+				liquid.AvailabilityZoneAny: {Usage: 0},
+			},
+		},
 		"members": {
 			Quota: swag.Int64(0),
 			PerAZ: map[liquid.AvailabilityZone]*liquid.AZResourceUsageReport{
@@ -137,6 +143,11 @@ func (l *liquidLogic) BuildServiceInfo(_ context.Context) (liquid.ServiceInfo, e
 				HasQuota:    true,
 				Topology:    liquid.FlatTopology,
 			},
+			"domains_f5": {
+				HasCapacity: false,
+				HasQuota:    true,
+				Topology:    liquid.FlatResourceTopology,
+			},
 			"members": {
 				HasCapacity: false,
 				HasQuota:    true,
@@ -188,6 +199,12 @@ func (l *liquidLogic) ScanUsage(ctx context.Context, projectUUID string, req liq
 					liquid.AvailabilityZoneAny: {Usage: uint64(resp.Payload.Quota.QuotaUsage.InUseDomainAkamai)},
 				},
 			},
+			"domains_f5": {
+				Quota: resp.Payload.Quota.DomainF5,
+				PerAZ: map[liquid.AvailabilityZone]*liquid.AZResourceUsageReport{
+					liquid.AvailabilityZoneAny: {Usage: uint64(resp.Payload.Quota.QuotaUsage.InUseDomainF5)},
+				},
+			},
 			"members": {
 				Quota: resp.Payload.Quota.Member,
 				PerAZ: map[liquid.AvailabilityZone]*liquid.AZResourceUsageReport{
@@ -216,6 +233,7 @@ func (l *liquidLogic) SetQuota(ctx context.Context, projectUUID string, req liqu
 	params.Quota = administrative.PutQuotasProjectIDBody{Quota: &models.Quota{
 		Datacenter:   func(num uint64) *int64 { i := int64(num); return &i }(req.Resources["datacenters"].Quota),
 		DomainAkamai: func(num uint64) *int64 { i := int64(num); return &i }(req.Resources["domains_akamai"].Quota),
+		DomainF5:     func(num uint64) *int64 { i := int64(num); return &i }(req.Resources["domains_f5"].Quota),
 		Member:       func(num uint64) *int64 { i := int64(num); return &i }(req.Resources["members"].Quota),
 		Monitor:      func(num uint64) *int64 { i := int64(num); return &i }(req.Resources["monitors"].Quota),
 		Pool:         func(num uint64) *int64 { i := int64(num); return &i }(req.Resources["pools"].Quota),

--- a/cmd/andromeda-liquid-server/main.go
+++ b/cmd/andromeda-liquid-server/main.go
@@ -146,7 +146,7 @@ func (l *liquidLogic) BuildServiceInfo(_ context.Context) (liquid.ServiceInfo, e
 			"domains_f5": {
 				HasCapacity: false,
 				HasQuota:    true,
-				Topology:    liquid.FlatResourceTopology,
+				Topology:    liquid.FlatTopology,
 			},
 			"members": {
 				HasCapacity: false,

--- a/cmd/andromeda-migrate/main.go
+++ b/cmd/andromeda-migrate/main.go
@@ -27,6 +27,16 @@ func main() {
 	config.ParseArgsAndRun("andromeda-migrate", "database migration tool",
 		func(c *cli.Context) error {
 			dbUrl := config.Global.Database.Connection
+			if c.String("db-url") != "" {
+				dbUrl = c.String("db-url")
+			}
 			return db.Migrate(dbUrl)
-		})
+		},
+		&cli.StringFlag{
+			Name:    "db-url",
+			Usage:   "Database connection URL (overrides value provided in config file)",
+			Value:   "",
+			EnvVars: []string{"DB_URL"},
+		},
+	)
 }

--- a/db/migrations/mysql/000007_rename_quota_tbl_domain_col.down.sql
+++ b/db/migrations/mysql/000007_rename_quota_tbl_domain_col.down.sql
@@ -1,0 +1,17 @@
+/*
+ *   Copyright 2025 SAP SE
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+ALTER TABLE quota RENAME COLUMN domain_akamai TO domain;

--- a/db/migrations/mysql/000007_rename_quota_tbl_domain_col.up.sql
+++ b/db/migrations/mysql/000007_rename_quota_tbl_domain_col.up.sql
@@ -1,0 +1,17 @@
+/*
+ *   Copyright 2025 SAP SE
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+ALTER TABLE quota RENAME COLUMN domain TO domain_akamai;

--- a/db/migrations/mysql/000008_add_domain_f5_col_to_quota_tbl.down.sql
+++ b/db/migrations/mysql/000008_add_domain_f5_col_to_quota_tbl.down.sql
@@ -1,0 +1,17 @@
+/*
+ *   Copyright 2025 SAP SE
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+ALTER TABLE `quota` DROP COLUMN `domain_f5`;

--- a/db/migrations/mysql/000008_add_domain_f5_col_to_quota_tbl.up.sql
+++ b/db/migrations/mysql/000008_add_domain_f5_col_to_quota_tbl.up.sql
@@ -1,0 +1,17 @@
+/*
+ *   Copyright 2025 SAP SE
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+ALTER TABLE `quota` ADD COLUMN `domain_f5` bigint(20) NOT NULL AFTER `domain_akamai`;

--- a/db/migrations/postgresql/000003_rename_quota_tbl_domain_col.down.sql
+++ b/db/migrations/postgresql/000003_rename_quota_tbl_domain_col.down.sql
@@ -1,0 +1,17 @@
+/*
+ *   Copyright 2025 SAP SE
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+ALTER TABLE quota RENAME COLUMN domain_akamai TO domain;

--- a/db/migrations/postgresql/000003_rename_quota_tbl_domain_col.up.sql
+++ b/db/migrations/postgresql/000003_rename_quota_tbl_domain_col.up.sql
@@ -1,0 +1,17 @@
+/*
+ *   Copyright 2025 SAP SE
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+ALTER TABLE quota RENAME COLUMN domain TO domain_akamai;

--- a/db/migrations/postgresql/000004_add_domain_f5_col_to_quota_tbl.down.sql
+++ b/db/migrations/postgresql/000004_add_domain_f5_col_to_quota_tbl.down.sql
@@ -1,0 +1,17 @@
+/*
+ *   Copyright 2025 SAP SE
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+ALTER TABLE quota DROP COLUMN domain_f5;

--- a/db/migrations/postgresql/000004_add_domain_f5_col_to_quota_tbl.up.sql
+++ b/db/migrations/postgresql/000004_add_domain_f5_col_to_quota_tbl.up.sql
@@ -1,0 +1,17 @@
+/*
+ *   Copyright 2025 SAP SE
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+ALTER TABLE quota ADD COLUMN domain_f5 bigint NOT NULL;

--- a/docs/api.md
+++ b/docs/api.md
@@ -3004,6 +3004,7 @@ Unexpected Error
 |------|------|---------|:--------:| ------- |-------------|---------|
 | datacenter | integer| `int64` |  | | The configured datacenter quota limit. A setting of null means it is using the deployment default quota. A setting of -1 means unlimited. | `5` |
 | domain_akamai | integer| `int64` |  | | The configured domain quota limit for provider Akamai. A setting of null means it is using the deployment default quota. A setting of -1 means unlimited. | `5` |
+| domain_f5 | integer| `int64` |  | | The configured domain quota limit for provider F5. A setting of null means it is using the deployment default quota. A setting of -1 means unlimited. | `5` |
 | member | integer| `int64` |  | | The configured member quota limit. A setting of null means it is using the deployment default quota. A setting of -1 means unlimited. | `5` |
 | monitor | integer| `int64` |  | | The configured monitor quota limit. A setting of null means it is using the deployment default quota. A setting of -1 means unlimited. | `5` |
 | pool | integer| `int64` |  | | The configured pool quota limit. A setting of null means it is using the deployment default quota. A setting of -1 means unlimited. | `5` |
@@ -3023,6 +3024,7 @@ Unexpected Error
 |------|------|---------|:--------:| ------- |-------------|---------|
 | in_use_datacenter | integer| `int64` |  | | The current quota usage of datacenter. | `5` |
 | in_use_domain_akamai | integer| `int64` |  | | The current quota usage of domain (provider = Akamai). | `5` |
+| in_use_domain_f5 | integer| `int64` |  | | The current quota usage of domain (provider = F5). | `5` |
 | in_use_member | integer| `int64` |  | | The current quota usage of member. | `5` |
 | in_use_monitor | integer| `int64` |  | | The current quota usage of monitor. | `5` |
 | in_use_pool | integer| `int64` |  | | The current quota usage of pool. | `5` |

--- a/docs/api.md
+++ b/docs/api.md
@@ -3003,7 +3003,7 @@ Unexpected Error
 | Name | Type | Go type | Required | Default | Description | Example |
 |------|------|---------|:--------:| ------- |-------------|---------|
 | datacenter | integer| `int64` |  | | The configured datacenter quota limit. A setting of null means it is using the deployment default quota. A setting of -1 means unlimited. | `5` |
-| domain | integer| `int64` |  | | The configured domain quota limit. A setting of null means it is using the deployment default quota. A setting of -1 means unlimited. | `5` |
+| domain_akamai | integer| `int64` |  | | The configured domain quota limit for provider Akamai. A setting of null means it is using the deployment default quota. A setting of -1 means unlimited. | `5` |
 | member | integer| `int64` |  | | The configured member quota limit. A setting of null means it is using the deployment default quota. A setting of -1 means unlimited. | `5` |
 | monitor | integer| `int64` |  | | The configured monitor quota limit. A setting of null means it is using the deployment default quota. A setting of -1 means unlimited. | `5` |
 | pool | integer| `int64` |  | | The configured pool quota limit. A setting of null means it is using the deployment default quota. A setting of -1 means unlimited. | `5` |
@@ -3022,7 +3022,7 @@ Unexpected Error
 | Name | Type | Go type | Required | Default | Description | Example |
 |------|------|---------|:--------:| ------- |-------------|---------|
 | in_use_datacenter | integer| `int64` |  | | The current quota usage of datacenter. | `5` |
-| in_use_domain | integer| `int64` |  | | The current quota usage of domain. | `5` |
+| in_use_domain_akamai | integer| `int64` |  | | The current quota usage of domain (provider = Akamai). | `5` |
 | in_use_member | integer| `int64` |  | | The current quota usage of member. | `5` |
 | in_use_monitor | integer| `int64` |  | | The current quota usage of monitor. | `5` |
 | in_use_pool | integer| `int64` |  | | The current quota usage of pool. | `5` |

--- a/internal/client/quota.go
+++ b/internal/client/quota.go
@@ -44,6 +44,7 @@ type QuotaUpdate struct {
 		ProjectID strfmt.UUID `description:"The ID of the project to update"`
 	} `positional-args:"yes" required:"yes"`
 	DomainAkamai *int64 `long:"domain_akamai" description:"Domains (provider Akamai) integer value"`
+	DomainF5     *int64 `long:"domain_f5" description:"Domains (provider F5) integer value"`
 	Datacenter   *int64 `long:"datacenter" description:"Datacenter integer value"`
 	Pool         *int64 `long:"pool" description:"Pool integer value"`
 	Member       *int64 `long:"member" description:"Member integer value"`
@@ -61,9 +62,9 @@ func (*QuotaList) Execute(_ []string) error {
 		return err
 	}
 
-	Table.AppendHeader(table.Row{"Project ID", "DomainsAkamai", "Datacenters", "Pools", "Members", "Monitors"})
+	Table.AppendHeader(table.Row{"Project ID", "DomainsAkamai", "DomainsF5", "Datacenters", "Pools", "Members", "Monitors"})
 	for _, quota := range resp.Payload.Quotas {
-		Table.AppendRow(table.Row{*quota.ProjectID, *quota.DomainAkamai, *quota.Datacenter, *quota.Pool,
+		Table.AppendRow(table.Row{*quota.ProjectID, *quota.DomainAkamai, *quota.DomainF5, *quota.Datacenter, *quota.Pool,
 			*quota.Member, *quota.Monitor})
 	}
 	Table.Render()
@@ -76,13 +77,14 @@ func (*QuotaDefaults) Execute(_ []string) error {
 		return err
 	}
 
-	Table.AppendHeader(table.Row{"DomainsAkamai", "Datacenters", "Pools", "Members", "Monitors"})
+	Table.AppendHeader(table.Row{"DomainsAkamai", "DomainsF5", "Datacenters", "Pools", "Members", "Monitors"})
 	domains_akamai := int(*resp.Payload.Quota.DomainAkamai)
+	domains_f5 := int(*resp.Payload.Quota.DomainF5)
 	datacenters := int(*resp.Payload.Quota.Datacenter)
 	pools := int(*resp.Payload.Quota.Pool)
 	members := int(*resp.Payload.Quota.Member)
 	monitors := int(*resp.Payload.Quota.Monitor)
-	Table.AppendRow(table.Row{domains_akamai, datacenters, pools, members, monitors})
+	Table.AppendRow(table.Row{domains_akamai, domains_f5, datacenters, pools, members, monitors})
 	Table.Render()
 	return nil
 }
@@ -106,6 +108,7 @@ func (*QuotaUpdate) Execute(_ []string) error {
 			Quota: &models.Quota{
 				Datacenter:   QuotaOptions.QuotaUpdate.Datacenter,
 				DomainAkamai: QuotaOptions.QuotaUpdate.DomainAkamai,
+				DomainF5:     QuotaOptions.QuotaUpdate.DomainF5,
 				Member:       QuotaOptions.QuotaUpdate.Member,
 				Monitor:      QuotaOptions.QuotaUpdate.Monitor,
 				Pool:         QuotaOptions.QuotaUpdate.Pool,

--- a/internal/client/quota.go
+++ b/internal/client/quota.go
@@ -43,11 +43,11 @@ type QuotaUpdate struct {
 	Positional struct {
 		ProjectID strfmt.UUID `description:"The ID of the project to update"`
 	} `positional-args:"yes" required:"yes"`
-	Domain     *int64 `long:"domain" description:"Domains integer value"`
-	Datacenter *int64 `long:"datacenter" description:"Datacenter integer value"`
-	Pool       *int64 `long:"pool" description:"Pool integer value"`
-	Member     *int64 `long:"member" description:"Member integer value"`
-	Monitor    *int64 `long:"monitor" description:"Monitor integer value"`
+	DomainAkamai *int64 `long:"domain_akamai" description:"Domains (provider Akamai) integer value"`
+	Datacenter   *int64 `long:"datacenter" description:"Datacenter integer value"`
+	Pool         *int64 `long:"pool" description:"Pool integer value"`
+	Member       *int64 `long:"member" description:"Member integer value"`
+	Monitor      *int64 `long:"monitor" description:"Monitor integer value"`
 }
 type QuotaDelete struct {
 	Positional struct {
@@ -61,9 +61,9 @@ func (*QuotaList) Execute(_ []string) error {
 		return err
 	}
 
-	Table.AppendHeader(table.Row{"Project ID", "Domains", "Datacenters", "Pools", "Members", "Monitors"})
+	Table.AppendHeader(table.Row{"Project ID", "DomainsAkamai", "Datacenters", "Pools", "Members", "Monitors"})
 	for _, quota := range resp.Payload.Quotas {
-		Table.AppendRow(table.Row{*quota.ProjectID, *quota.Domain, *quota.Datacenter, *quota.Pool,
+		Table.AppendRow(table.Row{*quota.ProjectID, *quota.DomainAkamai, *quota.Datacenter, *quota.Pool,
 			*quota.Member, *quota.Monitor})
 	}
 	Table.Render()
@@ -76,13 +76,13 @@ func (*QuotaDefaults) Execute(_ []string) error {
 		return err
 	}
 
-	Table.AppendHeader(table.Row{"Domains", "Datacenters", "Pools", "Members", "Monitors"})
-	domains := int(*resp.Payload.Quota.Domain)
+	Table.AppendHeader(table.Row{"DomainsAkamai", "Datacenters", "Pools", "Members", "Monitors"})
+	domains_akamai := int(*resp.Payload.Quota.DomainAkamai)
 	datacenters := int(*resp.Payload.Quota.Datacenter)
 	pools := int(*resp.Payload.Quota.Pool)
 	members := int(*resp.Payload.Quota.Member)
 	monitors := int(*resp.Payload.Quota.Monitor)
-	Table.AppendRow(table.Row{domains, datacenters, pools, members, monitors})
+	Table.AppendRow(table.Row{domains_akamai, datacenters, pools, members, monitors})
 	Table.Render()
 	return nil
 }
@@ -104,11 +104,11 @@ func (*QuotaUpdate) Execute(_ []string) error {
 		WithProjectID(QuotaOptions.QuotaUpdate.Positional.ProjectID.String()).
 		WithQuota(administrative.PutQuotasProjectIDBody{
 			Quota: &models.Quota{
-				Datacenter: QuotaOptions.QuotaUpdate.Datacenter,
-				Domain:     QuotaOptions.QuotaUpdate.Domain,
-				Member:     QuotaOptions.QuotaUpdate.Member,
-				Monitor:    QuotaOptions.QuotaUpdate.Monitor,
-				Pool:       QuotaOptions.QuotaUpdate.Pool,
+				Datacenter:   QuotaOptions.QuotaUpdate.Datacenter,
+				DomainAkamai: QuotaOptions.QuotaUpdate.DomainAkamai,
+				Member:       QuotaOptions.QuotaUpdate.Member,
+				Monitor:      QuotaOptions.QuotaUpdate.Monitor,
+				Pool:         QuotaOptions.QuotaUpdate.Pool,
 			},
 		})
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -185,6 +185,7 @@ type ApiSettings struct {
 type Quota struct {
 	Enabled                  bool  `yaml:"enabled" description:"Enable quotas."`
 	DefaultQuotaDomainAkamai int64 `yaml:"domains_akamai" default:"0" description:"Default quota of domain (provider Akamai) per project."`
+	DefaultQuotaDomainF5     int64 `yaml:"domains_f5" default:"0" description:"Default quota of domain (provider F5) per project."`
 	DefaultQuotaPool         int64 `yaml:"pools" default:"0" description:"Default quota of pool per project."`
 	DefaultQuotaMember       int64 `yaml:"members" default:"0" description:"Default quota of member per project."`
 	DefaultQuotaMonitor      int64 `yaml:"monitors" default:"0" description:"Default quota of monitor per project."`

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -183,12 +183,12 @@ type ApiSettings struct {
 }
 
 type Quota struct {
-	Enabled                bool  `yaml:"enabled" description:"Enable quotas."`
-	DefaultQuotaDomain     int64 `yaml:"domains" default:"0" description:"Default quota of domain per project."`
-	DefaultQuotaPool       int64 `yaml:"pools" default:"0" description:"Default quota of pool per project."`
-	DefaultQuotaMember     int64 `yaml:"members" default:"0" description:"Default quota of member per project."`
-	DefaultQuotaMonitor    int64 `yaml:"monitors" default:"0" description:"Default quota of monitor per project."`
-	DefaultQuotaDatacenter int64 `yaml:"datacenters" default:"0" description:"Default quota of datacenter per project."`
+	Enabled                  bool  `yaml:"enabled" description:"Enable quotas."`
+	DefaultQuotaDomainAkamai int64 `yaml:"domains_akamai" default:"0" description:"Default quota of domain (provider Akamai) per project."`
+	DefaultQuotaPool         int64 `yaml:"pools" default:"0" description:"Default quota of pool per project."`
+	DefaultQuotaMember       int64 `yaml:"members" default:"0" description:"Default quota of member per project."`
+	DefaultQuotaMonitor      int64 `yaml:"monitors" default:"0" description:"Default quota of monitor per project."`
+	DefaultQuotaDatacenter   int64 `yaml:"datacenters" default:"0" description:"Default quota of datacenter per project."`
 }
 
 type Default struct {

--- a/internal/controller/quota_test.go
+++ b/internal/controller/quota_test.go
@@ -37,7 +37,7 @@ func (t *SuiteTest) TestQuotas() {
 	assert.Equal(t.T(), rr.Code, http.StatusNotFound)
 
 	quota := administrative.PutQuotasProjectIDBody{}
-	_ = quota.UnmarshalBinary([]byte(`{ "quota": { "domain_akamai": 1234 } }`))
+	_ = quota.UnmarshalBinary([]byte(`{ "quota": { "domain_akamai": 1234, "domain_f5": 2345 } }`))
 
 	// Write new quota
 	res = dc.PutQuotasProjectID(administrative.PutQuotasProjectIDParams{
@@ -57,6 +57,7 @@ func (t *SuiteTest) TestQuotas() {
 	_ = quotasResponse.UnmarshalBinary(rr.Body.Bytes())
 	assert.Equal(t.T(), len(quotasResponse.Quotas), 1, rr.Body)
 	assert.Equal(t.T(), *quotasResponse.Quotas[0].DomainAkamai, int64(1234), rr.Body)
+	assert.Equal(t.T(), *quotasResponse.Quotas[0].DomainF5, int64(2345), rr.Body)
 
 	// Get specific quota
 	res = dc.GetQuotasProjectID(administrative.GetQuotasProjectIDParams{
@@ -78,7 +79,7 @@ func (t *SuiteTest) TestQuotasUpdateSelective() {
 	projectID := "test123"
 
 	quota := administrative.PutQuotasProjectIDBody{}
-	_ = quota.UnmarshalBinary([]byte(`{ "quota": { "domain_akamai": 1234 } }`))
+	_ = quota.UnmarshalBinary([]byte(`{ "quota": { "domain_akamai": 1234, "domain_f5": 2345 } }`))
 
 	// Write new quota
 	res := dc.PutQuotasProjectID(administrative.PutQuotasProjectIDParams{
@@ -87,7 +88,7 @@ func (t *SuiteTest) TestQuotasUpdateSelective() {
 	rr := httptest.NewRecorder()
 	res.WriteResponse(rr, runtime.JSONProducer())
 	assert.Equal(t.T(), http.StatusAccepted, rr.Code)
-	assert.JSONEq(t.T(), `{"quota":{"datacenter":0, "domain_akamai":1234, "member":0, "monitor":0, "pool":0}}`,
+	assert.JSONEq(t.T(), `{"quota":{"datacenter":0, "domain_akamai":1234, "domain_f5":2345, "member":0, "monitor":0, "pool":0}}`,
 		rr.Body.String())
 
 	// Update selective
@@ -99,6 +100,6 @@ func (t *SuiteTest) TestQuotasUpdateSelective() {
 	rr = httptest.NewRecorder()
 	res.WriteResponse(rr, runtime.JSONProducer())
 	assert.Equal(t.T(), http.StatusAccepted, rr.Code)
-	assert.JSONEq(t.T(), `{"quota":{"datacenter":1, "domain_akamai":1234, "member":0, "monitor":0, "pool":0}}`,
+	assert.JSONEq(t.T(), `{"quota":{"datacenter":1, "domain_akamai":1234, "domain_f5":2345, "member":0, "monitor":0, "pool":0}}`,
 		rr.Body.String())
 }

--- a/internal/controller/quota_test.go
+++ b/internal/controller/quota_test.go
@@ -37,7 +37,7 @@ func (t *SuiteTest) TestQuotas() {
 	assert.Equal(t.T(), rr.Code, http.StatusNotFound)
 
 	quota := administrative.PutQuotasProjectIDBody{}
-	_ = quota.UnmarshalBinary([]byte(`{ "quota": { "domain": 1234 } }`))
+	_ = quota.UnmarshalBinary([]byte(`{ "quota": { "domain_akamai": 1234 } }`))
 
 	// Write new quota
 	res = dc.PutQuotasProjectID(administrative.PutQuotasProjectIDParams{
@@ -56,7 +56,7 @@ func (t *SuiteTest) TestQuotas() {
 	quotasResponse := administrative.GetQuotasOKBody{}
 	_ = quotasResponse.UnmarshalBinary(rr.Body.Bytes())
 	assert.Equal(t.T(), len(quotasResponse.Quotas), 1, rr.Body)
-	assert.Equal(t.T(), *quotasResponse.Quotas[0].Domain, int64(1234), rr.Body)
+	assert.Equal(t.T(), *quotasResponse.Quotas[0].DomainAkamai, int64(1234), rr.Body)
 
 	// Get specific quota
 	res = dc.GetQuotasProjectID(administrative.GetQuotasProjectIDParams{
@@ -78,7 +78,7 @@ func (t *SuiteTest) TestQuotasUpdateSelective() {
 	projectID := "test123"
 
 	quota := administrative.PutQuotasProjectIDBody{}
-	_ = quota.UnmarshalBinary([]byte(`{ "quota": { "domain": 1234 } }`))
+	_ = quota.UnmarshalBinary([]byte(`{ "quota": { "domain_akamai": 1234 } }`))
 
 	// Write new quota
 	res := dc.PutQuotasProjectID(administrative.PutQuotasProjectIDParams{
@@ -87,7 +87,7 @@ func (t *SuiteTest) TestQuotasUpdateSelective() {
 	rr := httptest.NewRecorder()
 	res.WriteResponse(rr, runtime.JSONProducer())
 	assert.Equal(t.T(), http.StatusAccepted, rr.Code)
-	assert.JSONEq(t.T(), `{"quota":{"datacenter":0, "domain":1234, "member":0, "monitor":0, "pool":0}}`,
+	assert.JSONEq(t.T(), `{"quota":{"datacenter":0, "domain_akamai":1234, "member":0, "monitor":0, "pool":0}}`,
 		rr.Body.String())
 
 	// Update selective
@@ -99,6 +99,6 @@ func (t *SuiteTest) TestQuotasUpdateSelective() {
 	rr = httptest.NewRecorder()
 	res.WriteResponse(rr, runtime.JSONProducer())
 	assert.Equal(t.T(), http.StatusAccepted, rr.Code)
-	assert.JSONEq(t.T(), `{"quota":{"datacenter":1, "domain":1234, "member":0, "monitor":0, "pool":0}}`,
+	assert.JSONEq(t.T(), `{"quota":{"datacenter":1, "domain_akamai":1234, "member":0, "monitor":0, "pool":0}}`,
 		rr.Body.String())
 }

--- a/middlewares/quota.go
+++ b/middlewares/quota.go
@@ -79,10 +79,11 @@ func (qc *quotaController) QuotaHandler(next http.Handler) http.Handler {
 		var quotaAvailable, quotaUsed int
 
 		insert := sq.Insert("quota").
-			Columns("project_id", "domain_akamai", "pool", "member", "monitor", "datacenter").
+			Columns("project_id", "domain_akamai", "domain_f5", "pool", "member", "monitor", "datacenter").
 			Values(
 				project,
 				config.Global.Quota.DefaultQuotaDomainAkamai,
+				config.Global.Quota.DefaultQuotaDomainF5,
 				config.Global.Quota.DefaultQuotaPool,
 				config.Global.Quota.DefaultQuotaMember,
 				config.Global.Quota.DefaultQuotaMonitor,

--- a/middlewares/quota.go
+++ b/middlewares/quota.go
@@ -79,10 +79,10 @@ func (qc *quotaController) QuotaHandler(next http.Handler) http.Handler {
 		var quotaAvailable, quotaUsed int
 
 		insert := sq.Insert("quota").
-			Columns("project_id", "domain", "pool", "member", "monitor", "datacenter").
+			Columns("project_id", "domain_akamai", "pool", "member", "monitor", "datacenter").
 			Values(
 				project,
-				config.Global.Quota.DefaultQuotaDomain,
+				config.Global.Quota.DefaultQuotaDomainAkamai,
 				config.Global.Quota.DefaultQuotaPool,
 				config.Global.Quota.DefaultQuotaMember,
 				config.Global.Quota.DefaultQuotaMonitor,

--- a/models/datacenter.go
+++ b/models/datacenter.go
@@ -35,80 +35,80 @@ import (
 type Datacenter struct {
 
 	// The administrative state of the resource, which is up (true) or down (false). Default is true.
-	AdminStateUp *bool `json:"admin_state_up,omitempty"`
+	AdminStateUp *bool `json:"admin_state_up,omitempty" db:"admin_state_up,omitempty"`
 
 	// city
 	// Example: Berlin
 	// Max Length: 255
-	City *string `json:"city"`
+	City *string `json:"city" db:"city"`
 
 	// continent
 	// Example: EU
 	// Max Length: 255
-	Continent *string `json:"continent"`
+	Continent *string `json:"continent" db:"continent"`
 
 	// country
 	// Example: DE
 	// Max Length: 2
-	Country *string `json:"country"`
+	Country *string `json:"country" db:"country"`
 
 	// The UTC date and timestamp when the resource was created.
 	// Example: 2020-05-11T17:21:34
 	// Read Only: true
 	// Format: date-time
-	CreatedAt strfmt.DateTime `json:"created_at,omitempty"`
+	CreatedAt strfmt.DateTime `json:"created_at,omitempty" db:"created_at,omitempty"`
 
 	// The id of the resource.
 	// Read Only: true
 	// Format: uuid
-	ID strfmt.UUID `json:"id,omitempty"`
+	ID strfmt.UUID `json:"id,omitempty" db:"id,omitempty"`
 
 	// latitude
 	// Example: 52.526055
-	Latitude *float64 `json:"latitude"`
+	Latitude *float64 `json:"latitude" db:"latitude"`
 
 	// longitude
 	// Example: 13.403454
-	Longitude *float64 `json:"longitude"`
+	Longitude *float64 `json:"longitude" db:"longitude"`
 
 	// meta
 	// Read Only: true
-	Meta int64 `json:"meta,omitempty"`
+	Meta int64 `json:"meta,omitempty" db:"meta,omitempty"`
 
 	// Human-readable name of the resource.
 	// Max Length: 255
-	Name *string `json:"name,omitempty"`
+	Name *string `json:"name,omitempty" db:"name,omitempty"`
 
 	// The ID of the project owning this resource.
 	// Example: fa84c217f361441986a220edf9b1e337
 	// Max Length: 32
 	// Min Length: 32
-	ProjectID *string `json:"project_id,omitempty"`
+	ProjectID *string `json:"project_id,omitempty" db:"project_id,omitempty"`
 
 	// Provider driver for the backend solution
 	// Example: akamai
 	// Enum: [akamai f5]
-	Provider string `json:"provider,omitempty"`
+	Provider string `json:"provider,omitempty" db:"provider,omitempty"`
 
 	// provisioning status
 	// Read Only: true
 	// Enum: [PENDING_CREATE PENDING_UPDATE PENDING_DELETE ACTIVE ERROR]
-	ProvisioningStatus string `json:"provisioning_status,omitempty"`
+	ProvisioningStatus string `json:"provisioning_status,omitempty" db:"provisioning_status,omitempty"`
 
 	// Visibility of datacenter between different projects
 	// Enum: [private shared]
-	Scope *string `json:"scope,omitempty"`
+	Scope *string `json:"scope,omitempty" db:"scope,omitempty"`
 
 	// state or province
 	// Example: Berlin
 	// Max Length: 255
-	StateOrProvince *string `json:"state_or_province"`
+	StateOrProvince *string `json:"state_or_province" db:"state_or_province"`
 
 	// The UTC date and timestamp when the resource was created.
 	// Example: 2020-09-09T14:52:15
 	// Read Only: true
 	// Format: date-time
-	UpdatedAt strfmt.DateTime `json:"updated_at,omitempty"`
+	UpdatedAt strfmt.DateTime `json:"updated_at,omitempty" db:"updated_at,omitempty"`
 }
 
 // Validate validates this datacenter

--- a/models/domain.go
+++ b/models/domain.go
@@ -36,74 +36,74 @@ import (
 type Domain struct {
 
 	// The administrative state of the resource, which is up (true) or down (false). Default is true.
-	AdminStateUp *bool `json:"admin_state_up,omitempty"`
+	AdminStateUp *bool `json:"admin_state_up,omitempty" db:"admin_state_up,omitempty"`
 
 	// aliases
-	Aliases []string `json:"aliases"`
+	Aliases []string `json:"aliases" db:"aliases"`
 
 	// If not empty, the backend created a CNAME target to be used for the FQDN.
 	// Example: example.org.production.gtm.com
 	// Read Only: true
 	// Format: hostname
-	CnameTarget *strfmt.Hostname `json:"cname_target,omitempty"`
+	CnameTarget *strfmt.Hostname `json:"cname_target,omitempty" db:"cname_target,omitempty"`
 
 	// The UTC date and timestamp when the resource was created.
 	// Example: 2020-05-11T17:21:34
 	// Read Only: true
 	// Format: date-time
-	CreatedAt strfmt.DateTime `json:"created_at,omitempty"`
+	CreatedAt strfmt.DateTime `json:"created_at,omitempty" db:"created_at,omitempty"`
 
 	// Desired Fully-Qualified Host Name.
 	// Example: example.org
 	// Max Length: 512
 	// Format: hostname
-	Fqdn *strfmt.Hostname `json:"fqdn,omitempty"`
+	Fqdn *strfmt.Hostname `json:"fqdn,omitempty" db:"fqdn,omitempty"`
 
 	// The id of the resource.
 	// Read Only: true
 	// Format: uuid
-	ID strfmt.UUID `json:"id,omitempty"`
+	ID strfmt.UUID `json:"id,omitempty" db:"id,omitempty"`
 
 	// Load balancing method to use for the references pools.
 	// Enum: [WEIGHTED ROUND_ROBIN GEOGRAPHIC AVAILABILITY]
-	Mode *string `json:"mode,omitempty"`
+	Mode *string `json:"mode,omitempty" db:"mode,omitempty"`
 
 	// Human-readable name of the resource.
-	Name *string `json:"name,omitempty"`
+	Name *string `json:"name,omitempty" db:"name,omitempty"`
 
 	// pools
-	Pools []strfmt.UUID `json:"pools"`
+	Pools []strfmt.UUID `json:"pools" db:"pools"`
 
 	// The ID of the project owning this resource.
 	// Example: fa84c217f361441986a220edf9b1e337
 	// Max Length: 32
 	// Min Length: 32
-	ProjectID *string `json:"project_id,omitempty"`
+	ProjectID *string `json:"project_id,omitempty" db:"project_id,omitempty"`
 
 	// Supported provider drivers
 	// Example: akamai
 	// Enum: [akamai f5]
-	Provider *string `json:"provider,omitempty"`
+	Provider *string `json:"provider,omitempty" db:"provider,omitempty"`
 
 	// provisioning status
 	// Read Only: true
 	// Enum: [PENDING_CREATE PENDING_UPDATE PENDING_DELETE ACTIVE ERROR]
-	ProvisioningStatus string `json:"provisioning_status,omitempty"`
+	ProvisioningStatus string `json:"provisioning_status,omitempty" db:"provisioning_status,omitempty"`
 
 	// DNS Record type to use.
 	// Enum: [A AAAA CNAME MX]
-	RecordType *string `json:"record_type,omitempty"`
+	RecordType *string `json:"record_type,omitempty" db:"record_type,omitempty"`
 
 	// status
 	// Read Only: true
 	// Enum: [ONLINE DOWN]
-	Status string `json:"status,omitempty"`
+	Status string `json:"status,omitempty" db:"status,omitempty"`
 
 	// The UTC date and timestamp when the resource was created.
 	// Example: 2020-09-09T14:52:15
 	// Read Only: true
 	// Format: date-time
-	UpdatedAt strfmt.DateTime `json:"updated_at,omitempty"`
+	UpdatedAt strfmt.DateTime `json:"updated_at,omitempty" db:"updated_at,omitempty"`
 }
 
 // Validate validates this domain

--- a/models/error.go
+++ b/models/error.go
@@ -33,11 +33,11 @@ type Error struct {
 
 	// HTTP Error code
 	// Example: 404
-	Code int64 `json:"code,omitempty"`
+	Code int64 `json:"code,omitempty" db:"code,omitempty"`
 
 	// message
 	// Example: An example error message
-	Message string `json:"message,omitempty"`
+	Message string `json:"message,omitempty" db:"message,omitempty"`
 }
 
 // Validate validates this error

--- a/models/geomap.go
+++ b/models/geomap.go
@@ -36,53 +36,53 @@ import (
 type Geomap struct {
 
 	// Country to datacenter assignments.
-	Assignments []*GeomapAssignmentsItems0 `json:"assignments"`
+	Assignments []*GeomapAssignmentsItems0 `json:"assignments" db:"assignments"`
 
 	// The UTC date and timestamp when the resource was created.
 	// Example: 2020-05-11T17:21:34
 	// Read Only: true
 	// Format: date-time
-	CreatedAt strfmt.DateTime `json:"created_at,omitempty"`
+	CreatedAt strfmt.DateTime `json:"created_at,omitempty" db:"created_at,omitempty"`
 
 	// Datacenter ID
 	// Required: true
 	// Format: uuid
-	DefaultDatacenter *strfmt.UUID `json:"default_datacenter"`
+	DefaultDatacenter *strfmt.UUID `json:"default_datacenter" db:"default_datacenter"`
 
 	// The id of the resource.
 	// Read Only: true
 	// Format: uuid
-	ID strfmt.UUID `json:"id,omitempty"`
+	ID strfmt.UUID `json:"id,omitempty" db:"id,omitempty"`
 
 	// Human-readable name of the resource.
 	// Max Length: 255
-	Name *string `json:"name,omitempty"`
+	Name *string `json:"name,omitempty" db:"name,omitempty"`
 
 	// The ID of the project owning this resource.
 	// Example: fa84c217f361441986a220edf9b1e337
 	// Max Length: 32
 	// Min Length: 32
-	ProjectID *string `json:"project_id,omitempty"`
+	ProjectID *string `json:"project_id,omitempty" db:"project_id,omitempty"`
 
 	// Provider driver for the backend solution
 	// Example: akamai
 	// Enum: [akamai f5]
-	Provider string `json:"provider,omitempty"`
+	Provider string `json:"provider,omitempty" db:"provider,omitempty"`
 
 	// provisioning status
 	// Read Only: true
 	// Enum: [PENDING_CREATE PENDING_UPDATE PENDING_DELETE ACTIVE ERROR]
-	ProvisioningStatus string `json:"provisioning_status,omitempty"`
+	ProvisioningStatus string `json:"provisioning_status,omitempty" db:"provisioning_status,omitempty"`
 
 	// Visibility of datacenter between different projects
 	// Enum: [private shared]
-	Scope *string `json:"scope,omitempty"`
+	Scope *string `json:"scope,omitempty" db:"scope,omitempty"`
 
 	// The UTC date and timestamp when the resource was created.
 	// Example: 2020-09-09T14:52:15
 	// Read Only: true
 	// Format: date-time
-	UpdatedAt strfmt.DateTime `json:"updated_at,omitempty"`
+	UpdatedAt strfmt.DateTime `json:"updated_at,omitempty" db:"updated_at,omitempty"`
 }
 
 // Validate validates this geomap
@@ -485,11 +485,11 @@ type GeomapAssignmentsItems0 struct {
 	// ISO 3166 2-Letter Country code.
 	// Max Length: 2
 	// Min Length: 2
-	Country string `json:"country,omitempty"`
+	Country string `json:"country,omitempty" db:"country,omitempty"`
 
 	// Datacenter ID
 	// Format: uuid
-	Datacenter strfmt.UUID `json:"datacenter,omitempty"`
+	Datacenter strfmt.UUID `json:"datacenter,omitempty" db:"datacenter,omitempty"`
 }
 
 // Validate validates this geomap assignments items0

--- a/models/link.go
+++ b/models/link.go
@@ -36,11 +36,11 @@ type Link struct {
 
 	// href
 	// Format: uri
-	Href strfmt.URI `json:"href,omitempty"`
+	Href strfmt.URI `json:"href,omitempty" db:"href,omitempty"`
 
 	// rel
 	// Enum: [next previous]
-	Rel string `json:"rel,omitempty"`
+	Rel string `json:"rel,omitempty" db:"rel,omitempty"`
 }
 
 // Validate validates this link

--- a/models/member.go
+++ b/models/member.go
@@ -37,61 +37,61 @@ type Member struct {
 	// Address to use.
 	// Example: 1.2.3.4
 	// Format: ipv4
-	Address *strfmt.IPv4 `json:"address,omitempty"`
+	Address *strfmt.IPv4 `json:"address,omitempty" db:"address,omitempty"`
 
 	// The administrative state of the resource, which is up (true) or down (false). Default is true.
-	AdminStateUp *bool `json:"admin_state_up,omitempty"`
+	AdminStateUp *bool `json:"admin_state_up,omitempty" db:"admin_state_up,omitempty"`
 
 	// The UTC date and timestamp when the resource was created.
 	// Example: 2020-05-11T17:21:34
 	// Read Only: true
 	// Format: date-time
-	CreatedAt strfmt.DateTime `json:"created_at,omitempty"`
+	CreatedAt strfmt.DateTime `json:"created_at,omitempty" db:"created_at,omitempty"`
 
 	// Datacenter assigned for this member.
 	// Format: uuid
-	DatacenterID *strfmt.UUID `json:"datacenter_id,omitempty"`
+	DatacenterID *strfmt.UUID `json:"datacenter_id,omitempty" db:"datacenter_id,omitempty"`
 
 	// The id of the resource.
 	// Read Only: true
 	// Format: uuid
-	ID strfmt.UUID `json:"id,omitempty"`
+	ID strfmt.UUID `json:"id,omitempty" db:"id,omitempty"`
 
 	// Human-readable name of the resource.
 	// Max Length: 255
-	Name *string `json:"name,omitempty"`
+	Name *string `json:"name,omitempty" db:"name,omitempty"`
 
 	// pool id.
 	// Format: uuid
-	PoolID *strfmt.UUID `json:"pool_id,omitempty"`
+	PoolID *strfmt.UUID `json:"pool_id,omitempty" db:"pool_id,omitempty"`
 
 	// Port to use for monitor checks.
 	// Example: 80
 	// Maximum: 65535
 	// Minimum: 0
-	Port *int64 `json:"port,omitempty"`
+	Port *int64 `json:"port,omitempty" db:"port,omitempty"`
 
 	// The ID of the project owning this resource.
 	// Example: fa84c217f361441986a220edf9b1e337
 	// Max Length: 32
 	// Min Length: 32
-	ProjectID *string `json:"project_id,omitempty"`
+	ProjectID *string `json:"project_id,omitempty" db:"project_id,omitempty"`
 
 	// provisioning status
 	// Read Only: true
 	// Enum: [PENDING_CREATE PENDING_UPDATE PENDING_DELETE ACTIVE ERROR]
-	ProvisioningStatus string `json:"provisioning_status,omitempty"`
+	ProvisioningStatus string `json:"provisioning_status,omitempty" db:"provisioning_status,omitempty"`
 
 	// status
 	// Read Only: true
 	// Enum: [ONLINE NO_MONITOR OFFLINE]
-	Status string `json:"status,omitempty"`
+	Status string `json:"status,omitempty" db:"status,omitempty"`
 
 	// The UTC date and timestamp when the resource was created.
 	// Example: 2020-09-09T14:52:15
 	// Read Only: true
 	// Format: date-time
-	UpdatedAt strfmt.DateTime `json:"updated_at,omitempty"`
+	UpdatedAt strfmt.DateTime `json:"updated_at,omitempty" db:"updated_at,omitempty"`
 }
 
 // Validate validates this member

--- a/models/monitor.go
+++ b/models/monitor.go
@@ -35,80 +35,80 @@ import (
 type Monitor struct {
 
 	// The administrative state of the resource, which is up (true) or down (false). Default is true.
-	AdminStateUp *bool `json:"admin_state_up,omitempty"`
+	AdminStateUp *bool `json:"admin_state_up,omitempty" db:"admin_state_up,omitempty"`
 
 	// The UTC date and timestamp when the resource was created.
 	// Example: 2020-05-11T17:21:34
 	// Read Only: true
 	// Format: date-time
-	CreatedAt strfmt.DateTime `json:"created_at,omitempty"`
+	CreatedAt strfmt.DateTime `json:"created_at,omitempty" db:"created_at,omitempty"`
 
 	// The domain name, which be injected into the HTTP Host Header to the backend server for HTTP health check. Only used for HTTP/S monitors.
 	// Example: example.org
 	// Max Length: 255
 	// Format: hostname
-	DomainName *strfmt.Hostname `json:"domain_name,omitempty"`
+	DomainName *strfmt.Hostname `json:"domain_name,omitempty" db:"domain_name,omitempty"`
 
 	// HTTP method to use for monitor checks. Only used for HTTP/S monitors.
 	// Enum: [GET POST PUT HEAD PATCH DELETE OPTIONS]
-	HTTPMethod *string `json:"http_method,omitempty"`
+	HTTPMethod *string `json:"http_method,omitempty" db:"http_method,omitempty"`
 
 	// The id of the resource.
 	// Read Only: true
 	// Format: uuid
-	ID strfmt.UUID `json:"id,omitempty"`
+	ID strfmt.UUID `json:"id,omitempty" db:"id,omitempty"`
 
 	// The interval, in seconds, between health checks.
 	// Example: 10
 	// Maximum: 86399
 	// Minimum: 10
-	Interval *int64 `json:"interval,omitempty"`
+	Interval *int64 `json:"interval,omitempty" db:"interval,omitempty"`
 
 	// Human-readable name of the resource.
 	// Max Length: 255
-	Name *string `json:"name,omitempty"`
+	Name *string `json:"name,omitempty" db:"name,omitempty"`
 
 	// ID of the pool to check members
 	// Format: uuid
-	PoolID *strfmt.UUID `json:"pool_id,omitempty"`
+	PoolID *strfmt.UUID `json:"pool_id,omitempty" db:"pool_id,omitempty"`
 
 	// The ID of the project owning this resource.
 	// Example: fa84c217f361441986a220edf9b1e337
 	// Max Length: 32
 	// Min Length: 32
-	ProjectID *string `json:"project_id,omitempty"`
+	ProjectID *string `json:"project_id,omitempty" db:"project_id,omitempty"`
 
 	// provisioning status
 	// Read Only: true
 	// Enum: [PENDING_CREATE PENDING_UPDATE PENDING_DELETE ACTIVE ERROR]
-	ProvisioningStatus string `json:"provisioning_status,omitempty"`
+	ProvisioningStatus string `json:"provisioning_status,omitempty" db:"provisioning_status,omitempty"`
 
 	// Specifies the text string that the monitor expects to receive from the target member.
 	// Example: HTTP/1.
 	// Max Length: 255
-	Receive *string `json:"receive,omitempty"`
+	Receive *string `json:"receive,omitempty" db:"receive,omitempty"`
 
 	// Specifies the text string that the monitor sends to the target member. For HTTP/S monitors, this is a GET request and must be a HTTP path, e.g. `/status`.
 	// Example: /stats
 	// Max Length: 255
-	Send *string `json:"send,omitempty"`
+	Send *string `json:"send,omitempty" db:"send,omitempty"`
 
 	// The time in total, in seconds, after which a health check times out.
 	// Example: 30
 	// Maximum: 60
 	// Minimum: 0
-	Timeout *int64 `json:"timeout,omitempty"`
+	Timeout *int64 `json:"timeout,omitempty" db:"timeout,omitempty"`
 
 	// Type of the health check monitor.
 	// Example: HTTP
 	// Enum: [HTTP HTTPS ICMP TCP UDP]
-	Type *string `json:"type,omitempty"`
+	Type *string `json:"type,omitempty" db:"type,omitempty"`
 
 	// The UTC date and timestamp when the resource was created.
 	// Example: 2020-09-09T14:52:15
 	// Read Only: true
 	// Format: date-time
-	UpdatedAt strfmt.DateTime `json:"updated_at,omitempty"`
+	UpdatedAt strfmt.DateTime `json:"updated_at,omitempty" db:"updated_at,omitempty"`
 }
 
 // Validate validates this monitor

--- a/models/pool.go
+++ b/models/pool.go
@@ -36,55 +36,55 @@ import (
 type Pool struct {
 
 	// The administrative state of the resource, which is up (true) or down (false). Default is true.
-	AdminStateUp *bool `json:"admin_state_up,omitempty"`
+	AdminStateUp *bool `json:"admin_state_up,omitempty" db:"admin_state_up,omitempty"`
 
 	// The UTC date and timestamp when the resource was created.
 	// Example: 2020-05-11 17:21:34
 	// Read Only: true
 	// Format: date-time
-	CreatedAt strfmt.DateTime `json:"created_at,omitempty"`
+	CreatedAt strfmt.DateTime `json:"created_at,omitempty" db:"created_at,omitempty"`
 
 	// Array of domains assigned to this pool
-	Domains []strfmt.UUID `json:"domains"`
+	Domains []strfmt.UUID `json:"domains" db:"domains"`
 
 	// The id of the resource.
 	// Read Only: true
 	// Format: uuid
-	ID strfmt.UUID `json:"id,omitempty"`
+	ID strfmt.UUID `json:"id,omitempty" db:"id,omitempty"`
 
 	// Array of member ids that this pool uses for load balancing.
 	// Read Only: true
-	Members []strfmt.UUID `json:"members"`
+	Members []strfmt.UUID `json:"members" db:"members"`
 
 	// Array of monitor ids that this pool uses health checks.
 	// Read Only: true
-	Monitors []strfmt.UUID `json:"monitors"`
+	Monitors []strfmt.UUID `json:"monitors" db:"monitors"`
 
 	// Human-readable name of the resource.
 	// Max Length: 255
-	Name *string `json:"name,omitempty"`
+	Name *string `json:"name,omitempty" db:"name,omitempty"`
 
 	// The ID of the project owning this resource.
 	// Example: fa84c217f361441986a220edf9b1e337
 	// Max Length: 32
 	// Min Length: 32
-	ProjectID *string `json:"project_id,omitempty"`
+	ProjectID *string `json:"project_id,omitempty" db:"project_id,omitempty"`
 
 	// provisioning status
 	// Read Only: true
 	// Enum: [PENDING_CREATE PENDING_UPDATE PENDING_DELETE ACTIVE ERROR]
-	ProvisioningStatus string `json:"provisioning_status,omitempty"`
+	ProvisioningStatus string `json:"provisioning_status,omitempty" db:"provisioning_status,omitempty"`
 
 	// status
 	// Read Only: true
 	// Enum: [ONLINE DOWN]
-	Status string `json:"status,omitempty"`
+	Status string `json:"status,omitempty" db:"status,omitempty"`
 
 	// The UTC date and timestamp when the resource was created.
 	// Example: 2020-09-09 14:52:15
 	// Read Only: true
 	// Format: date-time
-	UpdatedAt strfmt.DateTime `json:"updated_at,omitempty"`
+	UpdatedAt strfmt.DateTime `json:"updated_at,omitempty" db:"updated_at,omitempty"`
 }
 
 // Validate validates this pool

--- a/models/quota.go
+++ b/models/quota.go
@@ -35,9 +35,9 @@ type Quota struct {
 	// Example: 5
 	Datacenter *int64 `json:"datacenter,omitempty"`
 
-	// The configured domain quota limit. A setting of null means it is using the deployment default quota. A setting of -1 means unlimited.
+	// The configured domain quota limit for provider Akamai. A setting of null means it is using the deployment default quota. A setting of -1 means unlimited.
 	// Example: 5
-	Domain *int64 `json:"domain,omitempty"`
+	DomainAkamai *int64 `json:"domain_akamai,omitempty"`
 
 	// The configured member quota limit. A setting of null means it is using the deployment default quota. A setting of -1 means unlimited.
 	// Example: 5

--- a/models/quota.go
+++ b/models/quota.go
@@ -33,23 +33,27 @@ type Quota struct {
 
 	// The configured datacenter quota limit. A setting of null means it is using the deployment default quota. A setting of -1 means unlimited.
 	// Example: 5
-	Datacenter *int64 `json:"datacenter,omitempty"`
+	Datacenter *int64 `json:"datacenter,omitempty" db:"datacenter,omitempty"`
 
 	// The configured domain quota limit for provider Akamai. A setting of null means it is using the deployment default quota. A setting of -1 means unlimited.
 	// Example: 5
-	DomainAkamai *int64 `json:"domain_akamai,omitempty"`
+	DomainAkamai *int64 `json:"domain_akamai,omitempty" db:"domain_akamai,omitempty"`
+
+	// The configured domain quota limit for provider F5. A setting of null means it is using the deployment default quota. A setting of -1 means unlimited.
+	// Example: 5
+	DomainF5 *int64 `json:"domain_f5,omitempty" db:"domain_f5,omitempty"`
 
 	// The configured member quota limit. A setting of null means it is using the deployment default quota. A setting of -1 means unlimited.
 	// Example: 5
-	Member *int64 `json:"member,omitempty"`
+	Member *int64 `json:"member,omitempty" db:"member,omitempty"`
 
 	// The configured monitor quota limit. A setting of null means it is using the deployment default quota. A setting of -1 means unlimited.
 	// Example: 5
-	Monitor *int64 `json:"monitor,omitempty"`
+	Monitor *int64 `json:"monitor,omitempty" db:"monitor,omitempty"`
 
 	// The configured pool quota limit. A setting of null means it is using the deployment default quota. A setting of -1 means unlimited.
 	// Example: 5
-	Pool *int64 `json:"pool,omitempty"`
+	Pool *int64 `json:"pool,omitempty" db:"pool,omitempty"`
 }
 
 // Validate validates this quota

--- a/models/quota_usage.go
+++ b/models/quota_usage.go
@@ -35,9 +35,9 @@ type QuotaUsage struct {
 	// Example: 5
 	InUseDatacenter int64 `json:"in_use_datacenter"`
 
-	// The current quota usage of domain.
+	// The current quota usage of domain (provider = Akamai).
 	// Example: 5
-	InUseDomain int64 `json:"in_use_domain"`
+	InUseDomainAkamai int64 `json:"in_use_domain_akamai"`
 
 	// The current quota usage of member.
 	// Example: 5

--- a/models/quota_usage.go
+++ b/models/quota_usage.go
@@ -33,23 +33,27 @@ type QuotaUsage struct {
 
 	// The current quota usage of datacenter.
 	// Example: 5
-	InUseDatacenter int64 `json:"in_use_datacenter"`
+	InUseDatacenter int64 `json:"in_use_datacenter" db:"in_use_datacenter"`
 
 	// The current quota usage of domain (provider = Akamai).
 	// Example: 5
-	InUseDomainAkamai int64 `json:"in_use_domain_akamai"`
+	InUseDomainAkamai int64 `json:"in_use_domain_akamai" db:"in_use_domain_akamai"`
+
+	// The current quota usage of domain (provider = F5).
+	// Example: 5
+	InUseDomainF5 int64 `json:"in_use_domain_f5" db:"in_use_domain_f5"`
 
 	// The current quota usage of member.
 	// Example: 5
-	InUseMember int64 `json:"in_use_member"`
+	InUseMember int64 `json:"in_use_member" db:"in_use_member"`
 
 	// The current quota usage of monitor.
 	// Example: 5
-	InUseMonitor int64 `json:"in_use_monitor"`
+	InUseMonitor int64 `json:"in_use_monitor" db:"in_use_monitor"`
 
 	// The current quota usage of pool.
 	// Example: 5
-	InUsePool int64 `json:"in_use_pool"`
+	InUsePool int64 `json:"in_use_pool" db:"in_use_pool"`
 }
 
 // Validate validates this quota usage

--- a/models/service.go
+++ b/models/service.go
@@ -36,35 +36,35 @@ type Service struct {
 	// The UTC date and timestamp when had the last heartbeat.
 	// Example: 2020-05-11 17:21:34
 	// Format: date-time
-	Heartbeat strfmt.DateTime `json:"heartbeat,omitempty"`
+	Heartbeat strfmt.DateTime `json:"heartbeat,omitempty" db:"heartbeat,omitempty"`
 
 	// Hostname of the computer the service is running.
 	// Example: example.host
 	// Format: hostname
-	Host strfmt.Hostname `json:"host,omitempty"`
+	Host strfmt.Hostname `json:"host,omitempty" db:"host,omitempty"`
 
 	// ID of the RPC service.
 	// Example: andromeda-agent-fbb49979-03f5-4a97-a334-1fd2c9f61e7e
-	ID string `json:"id,omitempty"`
+	ID string `json:"id,omitempty" db:"id,omitempty"`
 
 	// metadata
-	Metadata interface{} `json:"metadata,omitempty"`
+	Metadata interface{} `json:"metadata,omitempty" db:"metadata,omitempty"`
 
 	// Provider this service supports.
 	// Example: akamai
-	Provider string `json:"provider,omitempty"`
+	Provider string `json:"provider,omitempty" db:"provider,omitempty"`
 
 	// RPC Endpoint Address.
 	// Example: _INBOX.VEfFxcAzZQ9iM9vwGH49It
-	RPCAddress string `json:"rpc_address,omitempty"`
+	RPCAddress string `json:"rpc_address,omitempty" db:"rpc_address,omitempty"`
 
 	// Type of service.
 	// Example: healthcheck
-	Type string `json:"type,omitempty"`
+	Type string `json:"type,omitempty" db:"type,omitempty"`
 
 	// Version of the service.
 	// Example: 1.2.3
-	Version string `json:"version,omitempty"`
+	Version string `json:"version,omitempty" db:"version,omitempty"`
 }
 
 // Validate validates this service

--- a/restapi/embedded_spec.go
+++ b/restapi/embedded_spec.go
@@ -2555,6 +2555,12 @@ func init() {
           "x-nullable": true,
           "example": 5
         },
+        "domain_f5": {
+          "description": "The configured domain quota limit for provider F5. A setting of null means it is using the deployment default quota. A setting of -1 means unlimited.",
+          "type": "integer",
+          "x-nullable": true,
+          "example": 5
+        },
         "member": {
           "description": "The configured member quota limit. A setting of null means it is using the deployment default quota. A setting of -1 means unlimited.",
           "type": "integer",
@@ -2586,6 +2592,12 @@ func init() {
         },
         "in_use_domain_akamai": {
           "description": "The current quota usage of domain (provider = Akamai).",
+          "type": "integer",
+          "x-omitempty": false,
+          "example": 5
+        },
+        "in_use_domain_f5": {
+          "description": "The current quota usage of domain (provider = F5).",
           "type": "integer",
           "x-omitempty": false,
           "example": 5
@@ -5320,6 +5332,12 @@ func init() {
           "x-nullable": true,
           "example": 5
         },
+        "domain_f5": {
+          "description": "The configured domain quota limit for provider F5. A setting of null means it is using the deployment default quota. A setting of -1 means unlimited.",
+          "type": "integer",
+          "x-nullable": true,
+          "example": 5
+        },
         "member": {
           "description": "The configured member quota limit. A setting of null means it is using the deployment default quota. A setting of -1 means unlimited.",
           "type": "integer",
@@ -5351,6 +5369,12 @@ func init() {
         },
         "in_use_domain_akamai": {
           "description": "The current quota usage of domain (provider = Akamai).",
+          "type": "integer",
+          "x-omitempty": false,
+          "example": 5
+        },
+        "in_use_domain_f5": {
+          "description": "The current quota usage of domain (provider = F5).",
           "type": "integer",
           "x-omitempty": false,
           "example": 5

--- a/restapi/embedded_spec.go
+++ b/restapi/embedded_spec.go
@@ -2549,8 +2549,8 @@ func init() {
           "x-nullable": true,
           "example": 5
         },
-        "domain": {
-          "description": "The configured domain quota limit. A setting of null means it is using the deployment default quota. A setting of -1 means unlimited.",
+        "domain_akamai": {
+          "description": "The configured domain quota limit for provider Akamai. A setting of null means it is using the deployment default quota. A setting of -1 means unlimited.",
           "type": "integer",
           "x-nullable": true,
           "example": 5
@@ -2584,8 +2584,8 @@ func init() {
           "x-omitempty": false,
           "example": 5
         },
-        "in_use_domain": {
-          "description": "The current quota usage of domain.",
+        "in_use_domain_akamai": {
+          "description": "The current quota usage of domain (provider = Akamai).",
           "type": "integer",
           "x-omitempty": false,
           "example": 5
@@ -5314,8 +5314,8 @@ func init() {
           "x-nullable": true,
           "example": 5
         },
-        "domain": {
-          "description": "The configured domain quota limit. A setting of null means it is using the deployment default quota. A setting of -1 means unlimited.",
+        "domain_akamai": {
+          "description": "The configured domain quota limit for provider Akamai. A setting of null means it is using the deployment default quota. A setting of -1 means unlimited.",
           "type": "integer",
           "x-nullable": true,
           "example": 5
@@ -5349,8 +5349,8 @@ func init() {
           "x-omitempty": false,
           "example": 5
         },
-        "in_use_domain": {
-          "description": "The current quota usage of domain.",
+        "in_use_domain_akamai": {
+          "description": "The current quota usage of domain (provider = Akamai).",
           "type": "integer",
           "x-omitempty": false,
           "example": 5

--- a/swagger.yml
+++ b/swagger.yml
@@ -1821,6 +1821,11 @@ definitions:
         description: The configured domain quota limit for provider Akamai. A setting of null means it is using the deployment default quota. A setting of -1 means unlimited.
         example: 5
         x-nullable: true
+      domain_f5:
+        type: integer
+        description: The configured domain quota limit for provider F5. A setting of null means it is using the deployment default quota. A setting of -1 means unlimited.
+        example: 5
+        x-nullable: true
       pool:
         type: integer
         description: The configured pool quota limit. A setting of null means it is using the deployment default quota. A setting of -1 means unlimited.
@@ -1848,6 +1853,11 @@ definitions:
       in_use_domain_akamai:
         type: integer
         description: The current quota usage of domain (provider = Akamai).
+        example: 5
+        x-omitempty: false
+      in_use_domain_f5:
+        type: integer
+        description: The current quota usage of domain (provider = F5).
         example: 5
         x-omitempty: false
       in_use_pool:

--- a/swagger.yml
+++ b/swagger.yml
@@ -1816,9 +1816,9 @@ definitions:
   quota:
     type: object
     properties:
-      domain:
+      domain_akamai:
         type: integer
-        description: The configured domain quota limit. A setting of null means it is using the deployment default quota. A setting of -1 means unlimited.
+        description: The configured domain quota limit for provider Akamai. A setting of null means it is using the deployment default quota. A setting of -1 means unlimited.
         example: 5
         x-nullable: true
       pool:
@@ -1845,9 +1845,9 @@ definitions:
   quota_usage:
     type: object
     properties:
-      in_use_domain:
+      in_use_domain_akamai:
         type: integer
-        description: The current quota usage of domain.
+        description: The current quota usage of domain (provider = Akamai).
         example: 5
         x-omitempty: false
       in_use_pool:


### PR DESCRIPTION
What's been implemented:
* [X] renamed `quota.domain` to `quota.domain_akamai`
* [x] introduced `quota.domain_f5`