### PR TITLE
bump go-api-declarations from 1.14.0 to 1.14.3

### DIFF
--- a/cmd/andromeda-liquid-server/main.go
+++ b/cmd/andromeda-liquid-server/main.go
@@ -123,27 +123,27 @@ func (l *liquidLogic) BuildServiceInfo(_ context.Context) (liquid.ServiceInfo, e
 			"datacenters": {
 				HasCapacity: false,
 				HasQuota:    true,
-				Topology:    liquid.FlatResourceTopology,
+				Topology:    liquid.FlatTopology,
 			},
 			"domains": {
 				HasCapacity: false,
 				HasQuota:    true,
-				Topology:    liquid.FlatResourceTopology,
+				Topology:    liquid.FlatTopology,
 			},
 			"members": {
 				HasCapacity: false,
 				HasQuota:    true,
-				Topology:    liquid.FlatResourceTopology,
+				Topology:    liquid.FlatTopology,
 			},
 			"monitors": {
 				HasCapacity: false,
 				HasQuota:    true,
-				Topology:    liquid.FlatResourceTopology,
+				Topology:    liquid.FlatTopology,
 			},
 			"pools": {
 				HasCapacity: false,
 				HasQuota:    true,
-				Topology:    liquid.FlatResourceTopology,
+				Topology:    liquid.FlatTopology,
 			},
 		},
 		Rates:                  map[liquid.RateName]liquid.RateInfo{},

--- a/go.mod
+++ b/go.mod
@@ -39,7 +39,7 @@ require (
 	github.com/nats-io/nats.go v1.41.0
 	github.com/prometheus/client_golang v1.22.0
 	github.com/rs/cors v1.11.1
-	github.com/sapcc/go-api-declarations v1.14.0
+	github.com/sapcc/go-api-declarations v1.14.3
 	github.com/sapcc/go-bits v0.0.0-20250326161143-f8d9c0d68d83
 	github.com/scottdware/go-bigip v0.0.0-20240809002616-deb9b0aff84a
 	github.com/slok/go-http-metrics v0.13.0

--- a/go.sum
+++ b/go.sum
@@ -325,8 +325,8 @@ github.com/rs/cors v1.11.1/go.mod h1:XyqrcTp5zjWr1wsJ8PIRZssZ8b/WMcMf71DJnit4EMU
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/russross/blackfriday/v2 v2.1.0 h1:JIOH55/0cWyOuilr9/qlrm0BSXldqnqwMsf35Ld67mk=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
-github.com/sapcc/go-api-declarations v1.14.0 h1:L6PrfbAcbjg4fnlkuCzKrbCSAQMaMr2H1TiVLu7hZYU=
-github.com/sapcc/go-api-declarations v1.14.0/go.mod h1:KEYQoknn0gSjhmI19b85YUEZkav9SOu2bC21VeDNlnU=
+github.com/sapcc/go-api-declarations v1.14.3 h1:iDmwB8LGO+tkgW4A4nh1pILWIs7w4AM6f7SSMZtltSk=
+github.com/sapcc/go-api-declarations v1.14.3/go.mod h1:KEYQoknn0gSjhmI19b85YUEZkav9SOu2bC21VeDNlnU=
 github.com/sapcc/go-bits v0.0.0-20250326161143-f8d9c0d68d83 h1:rHyy8LP8rwRU6sPTv+aWrtePwVO7DXDaMtmKvCtrAfQ=
 github.com/sapcc/go-bits v0.0.0-20250326161143-f8d9c0d68d83/go.mod h1:aHyRA5cVj6mYujqg3xqIDyeyeaJihBAnSbyQvUfzfNU=
 github.com/scottdware/go-bigip v0.0.0-20240809002616-deb9b0aff84a h1:Dp0HN76Jl1n0orM9UVB/AnwqJOBWETm1hHBPDVMKWeE=


### PR DESCRIPTION
A manual solution for https://github.com/sapcc/andromeda/pull/811