### PR TITLE
fixed quota middleware unable to process domain creation

### DIFF
--- a/internal/utils/errors.go
+++ b/internal/utils/errors.go
@@ -53,6 +53,11 @@ func GetQuotaMetResponse(resource string) *models.Error {
 		"Quota has been met for Resource: %s", resource)}
 }
 
+func GetInvalidProviderBoundResourceResponse(resource string) *models.Error {
+	return &models.Error{Code: 403, Message: fmt.Sprintf(
+		"Cannot determine quota: provider missing for resource: %s", resource)}
+}
+
 func GetErrorPoolNotFound(poolID *strfmt.UUID) *models.Error {
 	return &models.Error{Code: 404, Message: fmt.Sprintf(
 		"invalid value for 'pool_id': Pool '%s' not found", poolID)}

--- a/middlewares/quota_test.go
+++ b/middlewares/quota_test.go
@@ -1,0 +1,42 @@
+package middlewares
+
+import (
+	"bytes"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestProviderFromHTTPRequestAcceptsRegularPayload(t *testing.T) {
+	jsonPayload := minimalNewDomainRequestPayload()
+	w := httptest.NewRecorder()
+	r, err := http.NewRequest("POST", "/domains", bytes.NewBuffer(jsonPayload))
+	r.Header.Set("Content-Type", "application/json")
+	assert.Nil(t, err)
+	expected := "akamai"
+	actual, err := providerFromHTTPRequest("domain", w, r)
+	assert.Nil(t, err)
+	assert.Equal(t, expected, actual)
+}
+
+func TestProviderFromHTTPRequestRejectsMaliciousPayload(t *testing.T) {
+	jsonPayload := arbitrarilySizedNewDomainRequestPayload(2 * 1024 * 1024) // 2MB
+	w := httptest.NewRecorder()
+	r, err := http.NewRequest("POST", "/domains", bytes.NewBuffer(jsonPayload))
+	r.Header.Set("Content-Type", "application/json")
+	assert.Nil(t, err)
+	_, err = providerFromHTTPRequest("domain", w, r)
+	assert.NotNil(t, err, "Unreasonably large request payloads should be rejected")
+}
+
+func minimalNewDomainRequestPayload() []byte {
+	return []byte(`{"domain": {"provider": "akamai"}}`)
+}
+
+func arbitrarilySizedNewDomainRequestPayload(size int) []byte {
+	payload := make([]byte, size)
+	copy(payload, minimalNewDomainRequestPayload())
+	return payload
+}


### PR DESCRIPTION
The previous `domain` resource to `quota.domain` column mapping no longer applies. A provider is required in order to produce such mapping (e.g. with provider `akamai` a `domain` resource then maps to `quota.domain_akamai`).

The fix was implemented in such a way that it's trivial to either break an existing resource quota per provider, or create a new resource type that is also bound by a provider.