### PR TITLE
Allows Andromeda Client to re-auth with Keystone.

### DIFF
--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -83,6 +83,7 @@ func SetupClient() {
 				ProjectName:       opts.OSProjectName,
 				ProjectDomainName: opts.OSProjectDomainName,
 				UserDomainName:    opts.OSUserDomainName,
+				AllowReauth:       true,
 			},
 		})
 		if err != nil {


### PR DESCRIPTION
This seems to work better than previous attempts. The Andromeda Liquid
Server will still show 500 errors from time to time but hopefully they
will be less common than they currently are.
