### PR TITLE
Fixes missing copyright info on Markdown docs

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -3,6 +3,12 @@
 
 # Andromeda
 Platform agnostic GSLB frontend
+
+```
+# SPDX-FileCopyrightText: Copyright 2025 SAP SE or an SAP affiliate company
+#
+# SPDX-License-Identifier: Apache-2.0
+```
   
 
 ## Informations

--- a/swagger.yml
+++ b/swagger.yml
@@ -5,7 +5,14 @@
 consumes:
 - application/json
 info:
-  description: Platform agnostic GSLB frontend
+  description: |-
+    Platform agnostic GSLB frontend
+
+    ```
+    # SPDX-FileCopyrightText: Copyright 2025 SAP SE or an SAP affiliate company
+    #
+    # SPDX-License-Identifier: Apache-2.0
+    ```
   title: Andromeda
   version: 1.1.1
 produces:


### PR DESCRIPTION
The `--copyright-file` CLI option seems to be ignored in the case of the Markdown docs generator.