### PR TITLE
fix: include missing `use-sync-external-store`

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -26,6 +26,7 @@
         "react-dom": "~18.3.1",
         "simple-zustand-devtools": "^1.1.0",
         "tailwindcss": "^4.1.3",
+        "use-sync-external-store": "^1.5.0",
         "zustand": "^5.0.3",
         "zustand-querystring": "^0.2.0"
       }
@@ -1817,6 +1818,16 @@
       },
       "peerDependencies": {
         "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.5.0.tgz",
+      "integrity": "sha512-Rb46I4cGGVBmjamjphe8L/UnvJD+uPPtTkNvX5mZgqdbavhI4EbgIWJiIHXJ8bc/i9EQGPRh4DwEURJ552Do0A==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/yallist": {

--- a/web/package.json
+++ b/web/package.json
@@ -23,6 +23,7 @@
     "react-dom": "~18.3.1",
     "simple-zustand-devtools": "^1.1.0",
     "tailwindcss": "^4.1.3",
+    "use-sync-external-store": "^1.5.0",
     "zustand": "^5.0.3",
     "zustand-querystring": "^0.2.0"
   },


### PR DESCRIPTION
Zustand 5 requires it, see:

<https://zustand.docs.pmnd.rs/migrations/migrating-to-v5#using-custom-equality-functions-such-as-shallow>
