### PR TITLE
fix: git-ignore appProps.json for local dev

### DIFF
--- a/web/.gitignore
+++ b/web/.gitignore
@@ -23,6 +23,7 @@
 .env.production.local
 secretProps.js
 secretProps.json
+public/appProps.json
 public/App*.js
 public/App*.js.map
 public/chunk*.js


### PR DESCRIPTION
This file is required for the webapp to load correctly.