### PR TITLE
feat: Enter keypress submits login form

### DIFF
--- a/web/src/components/LogInModal.js
+++ b/web/src/components/LogInModal.js
@@ -38,6 +38,13 @@ const LogInModal = ({keystoneEndpoint, overrideEndpoint, loginDomains, loginProj
         project: loginProject,
     })
 
+    const handleKeyDown = (event) => {
+        if (event.key === 'Enter') {
+            event.preventDefault()
+            onSubmit(event)
+        }
+    }
+
     const onSubmit = (event) => {
         setIsLoading(true)
         event.preventDefault();
@@ -136,6 +143,7 @@ const LogInModal = ({keystoneEndpoint, overrideEndpoint, loginDomains, loginProj
                         value={credentials.project}
                         disabled={isLoading}
                         onChange={handleChange}
+                        onKeyDown={handleKeyDown}
                         autoComplete="on"
                     />
                     <Button
@@ -153,6 +161,7 @@ const LogInModal = ({keystoneEndpoint, overrideEndpoint, loginDomains, loginProj
                                 value={credentials.username}
                                 disabled={isLoading}
                                 onChange={handleChange}
+                                onKeyDown={handleKeyDown}
                                 required
                             />
                         </FormRow>
@@ -164,6 +173,7 @@ const LogInModal = ({keystoneEndpoint, overrideEndpoint, loginDomains, loginProj
                                 value={credentials.password}
                                 disabled={isLoading}
                                 onChange={handleChange}
+                                onKeyDown={handleKeyDown}
                                 required
                             />
                         </FormRow>


### PR DESCRIPTION
This restores the expected default browser behavior of submitting a form when the Enter key is pressed while the focus is on a text input.