### PR TITLE
fix: Dockerfile bumped to Go 1.25

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-FROM golang:1.24-alpine AS builder
+FROM golang:1.25-alpine AS builder
 RUN apk add --no-cache make gcc musl-dev protoc git && go install google.golang.org/protobuf/cmd/protoc-gen-go@v1.28 && go install github.com/actatum/stormrpc/cmd/protoc-gen-stormrpc@latest
 
 COPY . /src

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ API Documentation: https://sapcc.github.io/andromeda/
 Andromeda provides a reference CLI client called `m31ctl` that uses the REST API of Andromeda.
 
 ## Running Requirements
-* go 1.24
+* go 1.25
 * NATS
 * SQL Database (PostgreSQL/MariaDB/CockroachDB)
 


### PR DESCRIPTION
Follow-up to 6362e724365d42e6ab69bb4abf90cd5fa9645e23