### PR TITLE
fix(web): update Safari target to 14.1 for esbuild 0.28.0 compatibility

### DIFF
--- a/web/esbuild.config.mjs
+++ b/web/esbuild.config.mjs
@@ -20,7 +20,7 @@ const serve = args.indexOf("--serve") >= 0
 let ctx = await esbuild.context({
     bundle: true,
     minify: isProduction,
-    target: ["es2020", "chrome64", "firefox67", "safari11.1", "edge79"],
+    target: ["es2020", "chrome64", "firefox67", "safari14.1", "edge79"],
     format: "esm",
     platform: "browser",
     loader: {".js": "jsx"},


### PR DESCRIPTION
esbuild 0.28.0 requires Safari 14.1+ for proper array destructuring
support. This fixes the build error:
"Transforming destructuring to the configured target environment is not
supported yet"

Related: https://github.com/evanw/esbuild/issues/4436
