### PR TITLE
fix(akamai): add propagation timeout to prevent worker thread from hanging

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -220,8 +220,9 @@ type AkamaiConfig struct {
 	Domain               string `yaml:"domain" description:"Traffic Management Domain to use (e.g. production.akadns.net)."`
 	DomainType           string `yaml:"domain_type" description:"Indicates the type of domain available based on your contract, defaults to autodetect. Either failover-only, static, weighted, basic, or full."`
 	ContractId           string `yaml:"contract_id" description:"Indicated the contract id to use, autodetects if only one contract is associated."`
-	SyncInterval         int64  `yaml:"sync_interval" default:"30" description:"Sync interval for checking for pending updates"`
-	MemberStatusInterval int64  `yaml:"member_status_interval" default:"60" description:"Sync interval for checking for member status"`
+	SyncInterval         int64 `yaml:"sync_interval" default:"30" description:"Sync interval for checking for pending updates"`
+	MemberStatusInterval int64 `yaml:"member_status_interval" default:"60" description:"Sync interval for checking for member status"`
+	PropagationTimeout   int64 `yaml:"propagation_timeout" default:"300" description:"Maximum time in seconds to wait for Akamai propagation before giving up"`
 }
 
 type Audit struct {

--- a/internal/driver/akamai/datacenter.go
+++ b/internal/driver/akamai/datacenter.go
@@ -114,7 +114,12 @@ func (s *AkamaiAgent) FetchAndSyncDatacenters(datacenters []string, force bool) 
 
 	// Wait for status propagation
 	var status string
+	deadline := time.Now().Add(time.Duration(config.Global.AkamaiConfig.PropagationTimeout) * time.Second)
 	for ok := true; ok; ok = status == "PENDING" {
+		if time.Now().After(deadline) {
+			log.Errorf("FetchAndSyncDatacenters: propagation timeout after %ds", config.Global.AkamaiConfig.PropagationTimeout)
+			break
+		}
 		time.Sleep(5 * time.Second)
 		status, err = s.syncProvisioningStatus(nil)
 		if err != nil {

--- a/internal/driver/akamai/domain.go
+++ b/internal/driver/akamai/domain.go
@@ -107,7 +107,12 @@ func (s *AkamaiAgent) FetchAndSyncDomains(domains []string, force bool) error {
 
 			// Wait for status propagation
 			var status string
+			deadline := time.Now().Add(time.Duration(config.Global.AkamaiConfig.PropagationTimeout) * time.Second)
 			for ok := true; ok; ok = status == "PENDING" {
+				if time.Now().After(deadline) {
+					log.Errorf("domainSync(%s): propagation timeout after %ds", domain.Id, config.Global.AkamaiConfig.PropagationTimeout)
+					break
+				}
 				time.Sleep(5 * time.Second)
 				status, err = s.syncProvisioningStatus(domain)
 				if err != nil {

--- a/internal/driver/akamai/geomap.go
+++ b/internal/driver/akamai/geomap.go
@@ -110,7 +110,12 @@ func (s *AkamaiAgent) FetchAndSyncGeomaps(geomaps []string, force bool) error {
 
 	// Wait for status propagation
 	var status string
+	deadline := time.Now().Add(time.Duration(config.Global.AkamaiConfig.PropagationTimeout) * time.Second)
 	for ok := true; ok; ok = status == "PENDING" {
+		if time.Now().After(deadline) {
+			log.Errorf("FetchAndSyncGeomaps: propagation timeout after %ds", config.Global.AkamaiConfig.PropagationTimeout)
+			break
+		}
 		time.Sleep(5 * time.Second)
 		status, err = s.syncProvisioningStatus(nil)
 		if err != nil {


### PR DESCRIPTION
The Akamai driver's WorkerThread could block indefinitely waiting for GTM propagation status to leave PENDING state. This starved all other sync operations and caused the driver to appear hung.

Add a configurable PropagationTimeout (default 300s) that breaks out of the polling loop if exceeded, allowing the sync loop to continue.