### PR TITLE
fix: replace deprecated reflect.Ptr with reflect.Pointer

### DIFF
--- a/internal/client/table_writer.go
+++ b/internal/client/table_writer.go
@@ -17,7 +17,7 @@ func formatValue(v reflect.Value) string {
 	switch kind := v.Kind(); kind {
 	case reflect.Bool:
 		return fmt.Sprintf("%t", v.Bool())
-	case reflect.Ptr:
+	case reflect.Pointer:
 		if v.IsNil() {
 			return "Null"
 		}
@@ -28,7 +28,7 @@ func formatValue(v reflect.Value) string {
 }
 
 func getRow(row reflect.Value, iMap []int) table.Row {
-	if row.Kind() == reflect.Ptr {
+	if row.Kind() == reflect.Pointer {
 		row = row.Elem()
 	}
 
@@ -45,7 +45,7 @@ func addSortedHeader(v reflect.Value) ([]int, error) {
 		Index  int
 	}
 
-	if v.Kind() == reflect.Ptr {
+	if v.Kind() == reflect.Pointer {
 		v = v.Elem()
 	}
 
@@ -112,7 +112,7 @@ func addSortedHeader(v reflect.Value) ([]int, error) {
 func WriteTable(data interface{}) error {
 	v := reflect.ValueOf(data)
 
-	if v.Kind() == reflect.Ptr {
+	if v.Kind() == reflect.Pointer {
 		// dereference: v = *v
 		v = v.Elem()
 	}

--- a/internal/utils/default.go
+++ b/internal/utils/default.go
@@ -38,7 +38,7 @@ func SetModelDefaults(s interface{}) error {
 				// Check if model has default set
 				if property.Default != nil {
 					propertyField := reflect.ValueOf(s).Elem().FieldByName(nameMangler.ToGoName(propName))
-					if propertyField.Kind() != reflect.Ptr && propertyField.Kind() != reflect.Uintptr {
+					if propertyField.Kind() != reflect.Pointer && propertyField.Kind() != reflect.Uintptr {
 						return fmt.Errorf("unexpected field %s for specDefinitionModel %s", propName, specDefinitionName)
 					}
 

--- a/internal/utils/equals.go
+++ b/internal/utils/equals.go
@@ -86,7 +86,7 @@ func deepValueEqualField(v1, v2 reflect.Value, fieldsToCompare []string) bool {
 			}
 		}
 		return true
-	case reflect.Ptr:
+	case reflect.Pointer:
 		if v1.Pointer() == v2.Pointer() {
 			return true
 		}


### PR DESCRIPTION
Fixes govet inline lint errors from golangci-lint 2.12.1.