### PR TITLE
ci: grant contents:write to update-swagger-ghpages

### DIFF
--- a/.github/workflows/update-swagger-ghpages.yml
+++ b/.github/workflows/update-swagger-ghpages.yml
@@ -10,6 +10,9 @@ on:
       - v*
     branches: [ main ]
 
+permissions:
+  contents: write
+
 jobs:
 
   build:


### PR DESCRIPTION
The workflow's GITHUB_TOKEN only had `contents: read`, so `git push` to `gh-pages` failed with 403 on every run. Adds an explicit `permissions: contents: write` so the push succeeds.